### PR TITLE
hyuuge changes

### DIFF
--- a/lib/4for4.js
+++ b/lib/4for4.js
@@ -44,8 +44,9 @@ exports.getADP = string => new Promise((resolve, reject) => {
     // Loop through each player, and see if it's the player we're looking for
     $('TR.odd, TR.even').each(function scanRows() {
       const player = $(this).children().first().next();
+
       // If this isn't the player we want, just move to the next row.
-      if (fuzzy(player.text(), playerName)*100 < 90) return true;
+      if (fuzzy(player.text(), playerName)*100 < 80) return true;
 
       // Otherwise, let's add them to the object!
       playerObject.name = player.text();

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -274,32 +274,9 @@ commands['!depthchart'] = (depthChartObject) => {
       const validPosition = [
         'qb',
         'rb',
-        'fb',
         'wr',
         'te',
-        'kr',
-        'pr',
         'k',
-        'lt',
-        'lg',
-        'c',
-        'rg',
-        'rt',
-        'ldt',
-        'lde',
-        'ndt',
-        'rdt',
-        'rde',
-        'mlb',
-        'slb',
-        'wlb',
-        'rcb',
-        'lcb',
-        'ss',
-        'fs',
-        'p',
-        'ls',
-        'h',
       ];
       // check to see if teamname and position was confused, if true, swap
       if (validPosition.includes(team.toLowerCase())) {
@@ -324,11 +301,11 @@ commands['!depthchart'] = (depthChartObject) => {
           .then((object) => {
             const embed = {
               embed: {
-                title: `${object.teamname}`,
+                title: `${object.teamname} ${position.toUpperCase()}`,
                 description: `${utilities.returnDepthChartStrings(
-                  object.teamname,
                   position,
                   object.roster[position],
+                  object.roster.update,
                 )}`,
                 url: object.url,
                 color: 11913417,

--- a/lib/depthchart.js
+++ b/lib/depthchart.js
@@ -1,145 +1,167 @@
 const request = require('request');
 const cheerio = require('cheerio');
+const utilities = require('./utilities.js');
 const teamLookup = require('../stats/teamLookup.json');
 
-const getDepthChart = (ros, posLookup, body) => {
-
-  const $ = cheerio.load(body)
+const getDepthChart = (depthChart, body) => {
+  // depthchart is an empty object
+  const $ = cheerio.load(body);
+  let lastUpdatedText = 'Last ' + $('.dc-upd').text();
+  let rosterObj = {};
   
-  const row1 = $('.row1');
-  const row2 = $('.row2');
-  for (let i = 2; i < row1.length; i += 1) {
-    const players = [];
-    const posLookupKey = $(row1[i])
-      .children()
-      .first()
-      .text()
-      .toLowerCase();
-    const pos = posLookup[posLookupKey];
-    $(row1[i]).children('td').find('a').each(function addPlayer() {
-      const data = $(this);
-      if (data.text() !== '') {
-        players.push(data.text());
-      }
-      return true;
-    });
-    if (pos) {
-      players.forEach((name) => {
-        ros[pos].push(name);
-      });
-    }
-  }
-  for (let i = 0; i < row2.length; i += 1) {
-    const players = [];
-    const posLookupKey = $(row2[i])
-      .children()
-      .first()
-      .text()
-      .toLowerCase();
-    const pos = posLookup[posLookupKey];
-    $(row2[i]).children('td').find('a').each(function addPlayer() {
-      if ($(this).text() !== '') {
-        players.push($(this).text());
-      }
-      return true;
-    });
-    if (pos) {
-      players.forEach((name) => {
-        ros[pos].push(name);
-      });
-    }
-  }
+  $('TR.row-dc-wht, TR.row-dc-grey').each(function eachRow() {
+    let names = []
+    let validPosition = ['lwr', 'rwr', 'swr', 'rb', 'te', 'qb', 'k'];
+    // get the text
+    let pos = $(this).children('td:nth-child(1)').text().toLowerCase();
 
-  Object.keys(ros).forEach((element) => {
-    if (ros[element].length === 0) {
-      ros[element].push('None Listed');
+    let p1 = utilities.depthChartSplit($(this).children('td:nth-child(3)').text())
+    let p2 = utilities.depthChartSplit($(this).children('td:nth-child(5)').text())
+    let p3 = utilities.depthChartSplit($(this).children('td:nth-child(7)').text())
+    let p4 = utilities.depthChartSplit($(this).children('td:nth-child(9)').text())
+    let p5 = utilities.depthChartSplit($(this).children('td:nth-child(11)').text())
+    // special case designation for kick, change from site pk to k
+    if (pos === 'pk') {
+      pos = 'k';
     }
-    return true;
+    
+    if (validPosition.includes(pos)) {
+      // merge wide receivers if the position is the same
+      if (pos === 'lwr' || pos === 'rwr' || pos === 'swr') {
+        // push names into players array
+        names.push(p1,p2,p3,p4,p5);
+        // capitalize first letter of first and last name
+        names = names.map(x => {
+          return utilities.capitalizeFirstLetterOfName(x);
+        })
+        
+        // check if key exist in obj 
+        if (pos in rosterObj) {
+          rosterObj[pos] = rosterObj[pos].concat(names);
+        } else {
+          rosterObj[pos] = names;
+        }
+       // special cases for 2 te/2 rb depth charts
+      } else if (pos === 'te' || pos === 'rb') {
+        let key = pos + '1'
+        names.push(p1,p2,p3,p4,p5);
+        names = names.map((x) => { 
+          return utilities.capitalizeFirstLetterOfName(x);
+        });
+        // check if key exist
+        if (key in rosterObj) {
+          rosterObj[pos + '2'] = names;
+        } else {
+          rosterObj[key] = names;
+        }        
+      } else {
+        names.push(p1,p2,p3,p4,p5);
+        names = names.map(x => {
+          return utilities.capitalizeFirstLetterOfName(x);
+        }).filter(Boolean);
+        rosterObj[pos] = names;
+      }
+    }
   });
 
-  return ros;
+  // final depth chart by merging cols
+  // check if swr, rwr, and lwr are listed
+  if ('swr' in rosterObj && 'rwr' in rosterObj && 'lwr' in rosterObj) {
+    let lwr = rosterObj['lwr'], rwr = rosterObj['rwr'], swr = rosterObj['swr'];
+    lwr.map((name, index) => {
+        depthChart['wr'].push(`LWR ${name}`);
+        depthChart['wr'].push(`RWR ${rwr[index]}`);
+        depthChart['wr'].push(`SWR ${swr[index]}`); 
+    });
+    // this filters out any spots with undefined in it
+    depthChart['wr'] = depthChart['wr'].filter((x) => !x.includes('undefined'));
+
+  //some team have only rwr and swr listed
+  } else if ('swr' in rosterObj && 'rwr' in rosterObj ){
+    let rwr = rosterObj['rwr'], swr = rosterObj['swr'];
+    rwr.map((name, index) => {
+        depthChart['wr'].push(`RWR ${name}`);
+        depthChart['wr'].push(`SWR ${swr[index]}`);
+    });
+    // this filters out any spots with undefined in it
+    depthChart['wr'] = depthChart['wr'].filter((x) => !x.includes('undefined'));
   
+    //some team have no swr listed
+  } else {
+    let lwr = rosterObj['lwr'], rwr = rosterObj['rwr'];
+    lwr.map((name, index) => {
+        depthChart['wr'].push(`LWR ${name}`);
+        depthChart['wr'].push(`RWR ${rwr[index]}`);
+    });
+    // this filters out any spots with undefined in it
+    depthChart['wr'] = depthChart['wr'].filter((x) => !x.includes('undefined'));
+  }
+
+  // if theres 2 starting rb
+  if ('rb2' in rosterObj) {
+    let rb1 = rosterObj['rb1'], rb2 = rosterObj['rb2'];
+    rb1.map((name, index) => {
+      depthChart['rb'].push(name);
+      depthChart['rb'].push(rb2[index]);
+    });
+    depthChart['rb'] = depthChart['rb'].filter(Boolean);
+  } else {
+    depthChart['rb'] = rosterObj['rb1'].filter(Boolean);
+  }
+
+  // if theres 2 te row
+  if ('te2' in rosterObj) {
+    let te1 = rosterObj['te1'], te2 = rosterObj['te2'];
+    te1.map((name, index) => {
+      depthChart['te'].push(name);
+      depthChart['te'].push(te2[index]);
+    });    
+    depthChart['te'] = depthChart['te'].filter(Boolean);
+  } else {
+    depthChart['te'] = rosterObj['te1'].filter(Boolean);
+  }
+  // kicker or qb
+
+  depthChart['qb'] = rosterObj['qb'].filter(Boolean);
+  depthChart['k'] = rosterObj['k'].filter(Boolean);
+  depthChart['update'] = lastUpdatedText;
+  
+  return depthChart
 
 };
 
 const getKey = (obj, val) => Object.keys(obj).find(key => obj[key] === val);
 
 exports.getRoster = (teamname, position) => {
-  let teamAbbreviation = teamname;
-  const team = teamLookup[teamname].name.toLowerCase();
-  const mascot = team.split(' ').pop();
-  const city = team.split(' ').join('-');
-
-  // special case for jacksonville using cbssports
-  if (teamname === 'JAX') {
-    teamAbbreviation = 'JAC';
+  let teamAbbreviation = teamname.toUpperCase();
+  // special case for arizone using ourlads
+  if (teamname === 'ARI') {
+    teamAbbreviation = 'ARZ';
   }
-  //https://www.cbssports.com/nfl/teams/BUF/buffalo-bills/depth-chart/
   return new Promise((resolve, reject) => {
-    const url = `https://www.cbssports.com/nfl/teams/depth-chart/${teamAbbreviation}/${city}-${mascot}/depth-chart/`;
-    const roster = { qb: [],
+    const url = `https://www.ourlads.com/nfldepthcharts/depthchart/${teamAbbreviation}`;
+    const depthChart = {
+      update: '',
+      qb: [],
       rb: [],
-      fb: [],
       wr: [],
       te: [],
-      lt: [],
-      lg: [],
-      c: [],
-      rg: [],
-      rt: [],
-      ldt: [],
-      lde: [],
-      ndt: [],
-      rdt: [],
-      rde: [],
-      mlb: [],
-      slb: [],
-      wlb: [],
-      rcb: [],
-      lcb: [],
-      ss: [],
-      fs: [],
-      p: [],
-      ls: [],
-      h: [],
-      k: [],
-      kr: [],
-      pr: [] };
-    const positionLookup = { quarterback: 'qb',
+      k: [] 
+    };
+
+    const positionLookup = { 
+      'quarterback': 'qb',
       'running back': 'rb',
-      'full back': 'fb',
       'wide receiver': 'wr',
       'tight end': 'te',
-      kicker: 'k',
-      'kick returner': 'kr',
-      'punt returner': 'pr',
-      'left tackle': 'lt',
-      'left guard': 'lg',
-      center: 'c',
-      'right guard': 'rg',
-      'right tackle': 'rt',
-      'left defensive tackle': 'ldt',
-      'left defensive end': 'lde',
-      'nose tackle': 'ndt',
-      'right defensive tackle': 'rdt',
-      'right defensive end': 'rde',
-      'middle linebacker': 'mlb',
-      'strongside linebacker': 'slb',
-      'weakside linebacker': 'wlb',
-      'right cornerback': 'rcb',
-      'left cornerback': 'lcb',
-      'strong safety': 'ss',
-      'free safety': 'fs',
-      punter: 'p',
-      'long snapper': 'ls',
-      holder: 'h' };
+      'kicker': 'k',
+    };
     request(url, (error, response, body) => {
       if (error && response.statusCode !== 200) {
         reject(error);
       }
-
       const results = {};
-      results.roster = getDepthChart(roster, positionLookup, body);
+      results.roster = getDepthChart(depthChart, body);
       results.logo = teamLookup[teamname].logo;
       results.teamname = teamLookup[teamname].name;
       results.url = url;

--- a/lib/pullroster.js
+++ b/lib/pullroster.js
@@ -1,46 +1,22 @@
-const depthchart = require('./depthchart.js');
+const request = require('request');
+const cheerio = require('cheerio');
 const nflteams = require('../stats/nflteamsdata.json');
-const lookup = require('../stats/teamLookup.json');
+const teamLookup = require('../stats/teamLookup.json');
 const fs = require('fs')
-
 let playersArray = [];
 
 
-for (let i = 0; i< nflteams.length; i++) {
+for (let i = 0; i < nflteams.length; i++) {
   setTimeout(() => {
-    getRosters(nflteams[i].abbreviation);
-  }, 4000*i);
+    getRosters(nflteams[i].abbreviation.toUpperCase());
+  }, 5000*i);
 }
 
 function getRosters(teamSymbol) {
   console.log(`pulling ${teamSymbol} roster data`);
-  let roster = depthchart.getRoster(teamSymbol, 'rb');
+  let roster = pullData(teamSymbol);
   roster.then((result) => {
-    let rosterObject = result.roster;
-    let symbol = teamSymbol;
-    let teamname = lookup[teamSymbol].name.toLowerCase();
-    let position = Object.keys(rosterObject);
-    position.map(position => {
-      if (position !== 'kr' && position !== 'pr') {
-        let obj = rosterObject[position];
-        obj.map(players => {
-          let player = players.toLowerCase().split(' ');
-          let fullname = players.toLowerCase();
-          let firstname = player[0];
-          let lastname = player[1];
-          let playerObject = {};
-          playerObject.team = teamname;
-          playerObject.symbol = symbol;
-          playerObject.fullname = fullname;
-          playerObject.first = firstname;
-          playerObject.last = lastname;
-          playerObject.position = position;
-          playersArray.push(playerObject);
-       });
-      }      
-    });
-
-    
+    playersArray = playersArray.concat(result);
     if (teamSymbol === 'DAL') {
       //this is the last team to pull and should output json data
       fs.writeFile('../stats/players.json', JSON.stringify(playersArray, null, 2), (err) => {
@@ -52,5 +28,53 @@ function getRosters(teamSymbol) {
       })
     }
   });
-  
+    
+}
+
+function pullData(team) {
+  return new Promise((resolve, reject) => {
+    let roster = [];
+    let teamname = teamLookup[team].name.toLowerCase();  
+    if (team === 'ARI') {
+      team = 'ARZ'
+    }
+    const url = `https://www.ourlads.com/nfldepthcharts/roster/${team}`;
+    request(url, (error, response, body) => {
+      if (error && response.statusCode !== 200) {
+        reject(error);
+      }
+      // depthchart is an empty object
+      const $ = cheerio.load(body);
+      $('TR.row-dc-wht, TR.row-dc-grey').each(function eachRow() {
+        // get the text
+        let rosterObj = {};
+        let offenseOnly = ['qb','rb', 'fb', 'te', 'wr', 'k']
+        let pos = $(this).children('td:nth-child(3)').text().toLowerCase();  
+        let p = $(this).children('td:nth-child(2)').text().toLowerCase();
+        // special case designation for kick, change from site pk to k
+        if (pos === 'pk') {
+          pos = 'k';
+        }
+        // in case player listed has 2 position, then we take his primary position
+        if (pos.includes('/')) {
+          pos = pos.split('/').shift()
+        }
+        if (offenseOnly.includes(pos)) {
+          let splitName = p.split(',').reverse()
+          let firstName = splitName[0].trim();
+          let lastName = splitName[1];
+          let fullName = `${firstName} ${lastName}`;
+          rosterObj.team = teamname;
+          rosterObj.symbol = team;
+          rosterObj.fullname = fullName;
+          rosterObj.first = firstName;
+          rosterObj.last = lastName;
+          rosterObj.position = pos;
+          roster.push(rosterObj)          
+        }
+      });
+
+      resolve(roster);
+    });
+  });
 }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -147,10 +147,46 @@ utilities.standardizePlayerName = (string) => {
   };
 };
 
-utilities.returnDepthChartStrings = (teamname, positionName, playerList) => {
-  let string = `${positionName.toUpperCase()} depth chart\n\n`;
-  for (let i = 0; i < playerList.length; i += 1) {
-    string += `${i + 1}. ${playerList[i]}\n`;
+utilities.returnDepthChartStrings = (positionName, playerList, lastUpdated) => {
+  let string = `*${lastUpdated}*\n\n`;
+  if (positionName === 'wr') {
+
+    let rwrSorted = [], lwrSorted = [], swrSorted = []
+    // sort them by position
+    playerList.map(x => {
+      if (x.includes('RWR')) {
+        rwrSorted.push(x.slice(4));
+      }
+      if (x.includes('LWR')) {
+        lwrSorted.push(x.slice(4));
+      }
+      if (x.includes('SWR')) {
+        swrSorted.push(x.slice(4));
+      }
+    });
+
+    if (rwrSorted.length !== 0) {
+      string += `**Right Receiver:** \n`
+      rwrSorted.map((x, index) => {
+        string += `${index+1}. ${x}\n`
+      });      
+    }
+    if (lwrSorted.length !== 0) {
+      string += `\n**Left Receiver:** \n`
+      lwrSorted.map((x, index) => {
+        string += `${index+1}. ${x}\n`
+      });      
+    }    
+    if (swrSorted.length !== 0) {
+      string += `\n**Slot Receiver:** \n`
+      swrSorted.map((x, index) => {
+        string += `${index+1}. ${x}\n`
+      });      
+    }
+  } else {
+    for (let i = 0; i < playerList.length; i += 1) {
+      string += `${i+1}. ${playerList[i]}\n`;
+    }    
   }
   return string;
 };
@@ -364,6 +400,38 @@ utilities.wdisHelper = (string) => {
 
   return final
 };
+
+utilities.depthChartSplit = (string) => {
+  //return if empty string
+  if (!string) return '';
+  let array = string.split(/[,]/)
+  // get last after split by comma
+  let lastName = array[0];
+  // get firstname after split, filtering the whitespace and return the first element of array
+  let firstName = array[1].split(' ').filter(Boolean).shift();
+  return `${firstName} ${lastName}`;
+};
+
+utilities.capitalizeFirstLetterOfName = (string) => {
+  // only does the operation if string exist
+  if (string) {
+    let splitted = string.toLowerCase().split(' ');
+    let romanNumerals = ['i','ii','iii','iv','v','vi','vii','viii','ix','x']
+    let name = '';
+    //change roman numerals back to upper case if its part of the name
+    if (romanNumerals.includes(splitted[splitted.length-1])) {
+      let last = splitted[splitted.length-1].toUpperCase();
+      splitted.pop();
+      splitted.push(last);
+    }
+
+    splitted.map(x => {
+      name += `${x.charAt(0).toUpperCase() + x.slice(1)} `;
+    });      
+  
+    return name 
+  }
+}
 
 module.exports = utilities;
 

--- a/stats/players.json
+++ b/stats/players.json
@@ -2,26 +2,18 @@
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "baker mayfield",
-    "first": "baker",
-    "last": "mayfield",
-    "position": "qb"
+    "fullname": "dorian baker",
+    "first": "dorian",
+    "last": "baker",
+    "position": "wr"
   },
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "drew stanton",
-    "first": "drew",
-    "last": "stanton",
-    "position": "qb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "garrett gilbert",
-    "first": "garrett",
-    "last": "gilbert",
-    "position": "qb"
+    "fullname": "odell beckham jr.",
+    "first": "odell",
+    "last": "beckham jr.",
+    "position": "wr"
   },
   {
     "team": "cleveland browns",
@@ -34,74 +26,10 @@
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "nick chubb",
-    "first": "nick",
-    "last": "chubb",
-    "position": "rb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "duke johnson",
-    "first": "duke",
-    "last": "johnson",
-    "position": "rb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "kareem hunt",
-    "first": "kareem",
-    "last": "hunt",
-    "position": "rb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "dontrell hilliard",
-    "first": "dontrell",
-    "last": "hilliard",
-    "position": "rb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "trayone gray",
-    "first": "trayone",
-    "last": "gray",
-    "position": "rb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "d'ernest johnson",
-    "first": "d'ernest",
-    "last": "johnson",
-    "position": "rb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "fb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "odell beckham",
-    "first": "odell",
-    "last": "beckham",
-    "position": "wr"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "jarvis landry",
-    "first": "jarvis",
-    "last": "landry",
-    "position": "wr"
+    "fullname": "pharaoh brown",
+    "first": "pharaoh",
+    "last": "brown",
+    "position": "te"
   },
   {
     "team": "cleveland browns",
@@ -114,105 +42,9 @@
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "rashard higgins",
-    "first": "rashard",
-    "last": "higgins",
-    "position": "wr"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "damion ratley",
-    "first": "damion",
-    "last": "ratley",
-    "position": "wr"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "derrick willies",
-    "first": "derrick",
-    "last": "willies",
-    "position": "wr"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "jaelen strong",
-    "first": "jaelen",
-    "last": "strong",
-    "position": "wr"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "blake jackson",
-    "first": "blake",
-    "last": "jackson",
-    "position": "wr"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "damon sheehy-guiseppi",
-    "first": "damon",
-    "last": "sheehy-guiseppi",
-    "position": "wr"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "ishmael hyman",
-    "first": "ishmael",
-    "last": "hyman",
-    "position": "wr"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "d.j. montgomery",
-    "first": "d.j.",
-    "last": "montgomery",
-    "position": "wr"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "dorian baker",
-    "first": "dorian",
-    "last": "baker",
-    "position": "wr"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "david njoku",
-    "first": "david",
-    "last": "njoku",
-    "position": "te"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "demetrius harris",
-    "first": "demetrius",
-    "last": "harris",
-    "position": "te"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "seth devalve",
-    "first": "seth",
-    "last": "devalve",
-    "position": "te"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "pharaoh brown",
-    "first": "pharaoh",
-    "last": "brown",
+    "fullname": "stephen carlson",
+    "first": "stephen",
+    "last": "carlson",
     "position": "te"
   },
   {
@@ -226,474 +58,146 @@
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "stephen carlson",
-    "first": "stephen",
-    "last": "carlson",
+    "fullname": "nick chubb",
+    "first": "nick",
+    "last": "chubb",
+    "position": "rb"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "mik'quan deane",
+    "first": "mik'quan",
+    "last": "deane",
     "position": "te"
   },
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "greg robinson",
+    "fullname": "seth devalve",
+    "first": "seth",
+    "last": "devalve",
+    "position": "wr"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "garrett gilbert",
+    "first": "garrett",
+    "last": "gilbert",
+    "position": "qb"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "trayone gray",
+    "first": "trayone",
+    "last": "gray",
+    "position": "rb"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "demetrius harris",
+    "first": "demetrius",
+    "last": "harris",
+    "position": "te"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "rashard higgins",
+    "first": "rashard",
+    "last": "higgins",
+    "position": "wr"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "dontrell hilliard",
+    "first": "dontrell",
+    "last": "hilliard",
+    "position": "rb"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "kareem hunt",
+    "first": "kareem",
+    "last": "hunt",
+    "position": "rb"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "ishmael hyman",
+    "first": "ishmael",
+    "last": "hyman",
+    "position": "wr"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "d'ernest johnson",
+    "first": "d'ernest",
+    "last": "johnson",
+    "position": "rb"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "greg joseph",
     "first": "greg",
-    "last": "robinson",
-    "position": "lt"
+    "last": "joseph",
+    "position": "k"
   },
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "joel bitonio",
-    "first": "joel",
-    "last": "bitonio",
-    "position": "lg"
+    "fullname": "jarvis landry",
+    "first": "jarvis",
+    "last": "landry",
+    "position": "wr"
   },
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "eric kush",
-    "first": "eric",
-    "last": "kush",
-    "position": "lg"
+    "fullname": "baker mayfield",
+    "first": "baker",
+    "last": "mayfield",
+    "position": "qb"
   },
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "jc tretter",
-    "first": "jc",
-    "last": "tretter",
-    "position": "c"
+    "fullname": "dj montgomery",
+    "first": "dj",
+    "last": "montgomery",
+    "position": "wr"
   },
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "kyle kalis",
-    "first": "kyle",
-    "last": "kalis",
-    "position": "c"
+    "fullname": "david njoku",
+    "first": "david",
+    "last": "njoku",
+    "position": "te"
   },
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "willie wright",
-    "first": "willie",
-    "last": "wright",
-    "position": "c"
+    "fullname": "aj ouellette",
+    "first": "aj",
+    "last": "ouellette",
+    "position": "rb"
   },
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "austin corbett",
-    "first": "austin",
-    "last": "corbett",
-    "position": "rg"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "bryan witzmann",
-    "first": "bryan",
-    "last": "witzmann",
-    "position": "rg"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "chris hubbard",
-    "first": "chris",
-    "last": "hubbard",
-    "position": "rt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "kendall lamm",
-    "first": "kendall",
-    "last": "lamm",
-    "position": "rt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "brad seaton",
-    "first": "brad",
-    "last": "seaton",
-    "position": "rt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "sheldon richardson",
-    "first": "sheldon",
-    "last": "richardson",
-    "position": "ldt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "trevon coley",
-    "first": "trevon",
-    "last": "coley",
-    "position": "ldt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "devaroe lawrence",
-    "first": "devaroe",
-    "last": "lawrence",
-    "position": "ldt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "olivier vernon",
-    "first": "olivier",
-    "last": "vernon",
-    "position": "lde"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "chris smith",
-    "first": "chris",
-    "last": "smith",
-    "position": "lde"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "wyatt ray",
-    "first": "wyatt",
-    "last": "ray",
-    "position": "lde"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "jarrell owens",
-    "first": "jarrell",
-    "last": "owens",
-    "position": "lde"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "larry ogunjobi",
-    "first": "larry",
-    "last": "ogunjobi",
-    "position": "rdt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "brian price",
-    "first": "brian",
-    "last": "price",
-    "position": "rdt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "carl davis",
-    "first": "carl",
-    "last": "davis",
-    "position": "rdt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "daniel ekuale",
-    "first": "daniel",
-    "last": "ekuale",
-    "position": "rdt"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "myles garrett",
-    "first": "myles",
-    "last": "garrett",
-    "position": "rde"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "chad thomas",
-    "first": "chad",
-    "last": "thomas",
-    "position": "rde"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "anthony zettel",
-    "first": "anthony",
-    "last": "zettel",
-    "position": "rde"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "joe schobert",
-    "first": "joe",
-    "last": "schobert",
-    "position": "mlb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "mack wilson",
-    "first": "mack",
-    "last": "wilson",
-    "position": "mlb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "willie harvey",
-    "first": "willie",
-    "last": "harvey",
-    "position": "mlb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "adarius taylor",
-    "first": "adarius",
-    "last": "taylor",
-    "position": "slb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "genard avery",
-    "first": "genard",
-    "last": "avery",
-    "position": "slb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "anthony stubbs",
-    "first": "anthony",
-    "last": "stubbs",
-    "position": "slb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "christian kirksey",
-    "first": "christian",
-    "last": "kirksey",
-    "position": "wlb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "sione takitaki",
-    "first": "sione",
-    "last": "takitaki",
-    "position": "wlb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "ray-ray armstrong",
-    "first": "ray-ray",
-    "last": "armstrong",
-    "position": "wlb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "terrance mitchell",
-    "first": "terrance",
-    "last": "mitchell",
-    "position": "rcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "greedy williams",
-    "first": "greedy",
-    "last": "williams",
-    "position": "rcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "eric murray",
-    "first": "eric",
-    "last": "murray",
-    "position": "rcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "robert jackson",
-    "first": "robert",
-    "last": "jackson",
-    "position": "rcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "juston burris",
-    "first": "juston",
-    "last": "burris",
-    "position": "rcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "lenzy pipkins",
-    "first": "lenzy",
-    "last": "pipkins",
-    "position": "rcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "jermaine ponder",
-    "first": "jermaine",
-    "last": "ponder",
-    "position": "rcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "denzel ward",
-    "first": "denzel",
-    "last": "ward",
-    "position": "lcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "t.j. carrie",
-    "first": "t.j.",
-    "last": "carrie",
-    "position": "lcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "phillip gaines",
-    "first": "phillip",
-    "last": "gaines",
-    "position": "lcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "tavierre thomas",
-    "first": "tavierre",
-    "last": "thomas",
-    "position": "lcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "donnie lewis",
-    "first": "donnie",
-    "last": "lewis",
-    "position": "lcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "jhavonte dean",
-    "first": "jhavonte",
-    "last": "dean",
-    "position": "lcb"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "morgan burnett",
-    "first": "morgan",
-    "last": "burnett",
-    "position": "ss"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "jermaine whitehead",
-    "first": "jermaine",
-    "last": "whitehead",
-    "position": "ss"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "j.t. hassell",
-    "first": "j.t.",
-    "last": "hassell",
-    "position": "ss"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "damarious randall",
-    "first": "damarious",
-    "last": "randall",
-    "position": "fs"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "sheldrick redwine",
-    "first": "sheldrick",
-    "last": "redwine",
-    "position": "fs"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "tigie sankoh",
-    "first": "tigie",
-    "last": "sankoh",
-    "position": "fs"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "britton colquitt",
-    "first": "britton",
-    "last": "colquitt",
-    "position": "p"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "jamie gillan",
-    "first": "jamie",
-    "last": "gillan",
-    "position": "p"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "charley hughlett",
-    "first": "charley",
-    "last": "hughlett",
-    "position": "ls"
-  },
-  {
-    "team": "cleveland browns",
-    "symbol": "CLE",
-    "fullname": "britton colquitt",
-    "first": "britton",
-    "last": "colquitt",
-    "position": "h"
+    "fullname": "damion ratley",
+    "first": "damion",
+    "last": "ratley",
+    "position": "wr"
   },
   {
     "team": "cleveland browns",
@@ -706,105 +210,33 @@
   {
     "team": "cleveland browns",
     "symbol": "CLE",
-    "fullname": "greg joseph",
-    "first": "greg",
-    "last": "joseph",
-    "position": "k"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "matthew stafford",
-    "first": "matthew",
-    "last": "stafford",
-    "position": "qb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "tom savage",
-    "first": "tom",
-    "last": "savage",
-    "position": "qb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "david fales",
-    "first": "david",
-    "last": "fales",
-    "position": "qb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "kerryon johnson",
-    "first": "kerryon",
-    "last": "johnson",
-    "position": "rb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "c.j. anderson",
-    "first": "c.j.",
-    "last": "anderson",
-    "position": "rb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "zach zenner",
-    "first": "zach",
-    "last": "zenner",
-    "position": "rb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "theo riddick",
-    "first": "theo",
-    "last": "riddick",
-    "position": "rb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "ty johnson",
-    "first": "ty",
-    "last": "johnson",
-    "position": "rb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "mark thompson",
-    "first": "mark",
-    "last": "thompson",
-    "position": "rb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "nick bawden",
-    "first": "nick",
-    "last": "bawden",
-    "position": "fb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "kenny golladay",
-    "first": "kenny",
-    "last": "golladay",
+    "fullname": "damon sheehy-guiseppi",
+    "first": "damon",
+    "last": "sheehy-guiseppi",
     "position": "wr"
   },
   {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "marvin jones",
-    "first": "marvin",
-    "last": "jones",
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "drew stanton",
+    "first": "drew",
+    "last": "stanton",
+    "position": "qb"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "jaelen strong",
+    "first": "jaelen",
+    "last": "strong",
+    "position": "wr"
+  },
+  {
+    "team": "cleveland browns",
+    "symbol": "CLE",
+    "fullname": "derrick willies",
+    "first": "derrick",
+    "last": "willies",
     "position": "wr"
   },
   {
@@ -818,58 +250,26 @@
   {
     "team": "detroit lions",
     "symbol": "DET",
-    "fullname": "jermaine kearse",
-    "first": "jermaine",
-    "last": "kearse",
-    "position": "wr"
+    "fullname": "cj anderson",
+    "first": "cj",
+    "last": "anderson",
+    "position": "rb"
   },
   {
     "team": "detroit lions",
     "symbol": "DET",
-    "fullname": "tommylee lewis",
-    "first": "tommylee",
-    "last": "lewis",
-    "position": "wr"
+    "fullname": "nick bawden",
+    "first": "nick",
+    "last": "bawden",
+    "position": "fb"
   },
   {
     "team": "detroit lions",
     "symbol": "DET",
-    "fullname": "andy jones",
-    "first": "andy",
-    "last": "jones",
-    "position": "wr"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "travis fulgham",
-    "first": "travis",
-    "last": "fulgham",
-    "position": "wr"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "brandon powell",
-    "first": "brandon",
-    "last": "powell",
-    "position": "wr"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "chris lacy",
-    "first": "chris",
-    "last": "lacy",
-    "position": "wr"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "deontez alexander",
-    "first": "deontez",
-    "last": "alexander",
-    "position": "wr"
+    "fullname": "jerome cunningham",
+    "first": "jerome",
+    "last": "cunningham",
+    "position": "te"
   },
   {
     "team": "detroit lions",
@@ -882,24 +282,32 @@
   {
     "team": "detroit lions",
     "symbol": "DET",
-    "fullname": "tom kennedy",
-    "first": "tom",
-    "last": "kennedy",
+    "fullname": "david fales",
+    "first": "david",
+    "last": "fales",
+    "position": "qb"
+  },
+  {
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "travis fulgham",
+    "first": "travis",
+    "last": "fulgham",
     "position": "wr"
   },
   {
     "team": "detroit lions",
     "symbol": "DET",
-    "fullname": "brandon reilly",
-    "first": "brandon",
-    "last": "reilly",
+    "fullname": "kenny golladay",
+    "first": "kenny",
+    "last": "golladay",
     "position": "wr"
   },
   {
     "team": "detroit lions",
     "symbol": "DET",
-    "fullname": "t.j. hockenson",
-    "first": "t.j.",
+    "fullname": "tj hockenson",
+    "first": "tj",
     "last": "hockenson",
     "position": "te"
   },
@@ -914,10 +322,66 @@
   {
     "team": "detroit lions",
     "symbol": "DET",
-    "fullname": "logan thomas",
-    "first": "logan",
-    "last": "thomas",
-    "position": "te"
+    "fullname": "kerryon johnson",
+    "first": "kerryon",
+    "last": "johnson",
+    "position": "rb"
+  },
+  {
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "ty johnson",
+    "first": "ty",
+    "last": "johnson",
+    "position": "rb"
+  },
+  {
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "andy jones",
+    "first": "andy",
+    "last": "jones",
+    "position": "wr"
+  },
+  {
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "marvin jones",
+    "first": "marvin",
+    "last": "jones",
+    "position": "wr"
+  },
+  {
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "jermaine kearse",
+    "first": "jermaine",
+    "last": "kearse",
+    "position": "wr"
+  },
+  {
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "tom kennedy",
+    "first": "tom",
+    "last": "kennedy",
+    "position": "wr"
+  },
+  {
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "chris lacy",
+    "first": "chris",
+    "last": "lacy",
+    "position": "wr"
+  },
+  {
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "tommylee lewis",
+    "first": "tommylee",
+    "last": "lewis",
+    "position": "wr"
   },
   {
     "team": "detroit lions",
@@ -930,490 +394,10 @@
   {
     "team": "detroit lions",
     "symbol": "DET",
-    "fullname": "jerome cunningham",
-    "first": "jerome",
-    "last": "cunningham",
-    "position": "te"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "taylor decker",
-    "first": "taylor",
-    "last": "decker",
-    "position": "lt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "oday aboushi",
-    "first": "oday",
-    "last": "aboushi",
-    "position": "lt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "ryan pope",
-    "first": "ryan",
-    "last": "pope",
-    "position": "lt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "andrew donnal",
-    "first": "andrew",
-    "last": "donnal",
-    "position": "lt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "frank ragnow",
-    "first": "frank",
-    "last": "ragnow",
-    "position": "lg"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "joe dahl",
-    "first": "joe",
-    "last": "dahl",
-    "position": "lg"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "beau benzschawel",
-    "first": "beau",
-    "last": "benzschawel",
-    "position": "lg"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "graham glasgow",
-    "first": "graham",
-    "last": "glasgow",
-    "position": "c"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "luke bowanko",
-    "first": "luke",
-    "last": "bowanko",
-    "position": "c"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "kenny wiggins",
-    "first": "kenny",
-    "last": "wiggins",
-    "position": "rg"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "leo koloamatangi",
-    "first": "leo",
-    "last": "koloamatangi",
-    "position": "rg"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "rick wagner",
-    "first": "rick",
-    "last": "wagner",
-    "position": "rt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "tyrell crosby",
-    "first": "tyrell",
-    "last": "crosby",
-    "position": "rt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "matt nelson",
-    "first": "matt",
-    "last": "nelson",
-    "position": "rt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "damon harrison",
-    "first": "damon",
-    "last": "harrison",
-    "position": "ldt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "john atkins",
-    "first": "john",
-    "last": "atkins",
-    "position": "ldt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "p.j. johnson",
-    "first": "p.j.",
-    "last": "johnson",
-    "position": "ldt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "ray smith",
-    "first": "ray",
-    "last": "smith",
-    "position": "ldt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "da'shawn hand",
-    "first": "da'shawn",
-    "last": "hand",
-    "position": "lde"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "romeo okwara",
-    "first": "romeo",
-    "last": "okwara",
-    "position": "lde"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "jonathan wynn",
-    "first": "jonathan",
-    "last": "wynn",
-    "position": "lde"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "a'shawn robinson",
-    "first": "a'shawn",
-    "last": "robinson",
-    "position": "rdt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "mitchell loewen",
-    "first": "mitchell",
-    "last": "loewen",
-    "position": "rdt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "darius kilgo",
-    "first": "darius",
-    "last": "kilgo",
-    "position": "rdt"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "trey flowers",
-    "first": "trey",
-    "last": "flowers",
-    "position": "rde"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "austin bryant",
-    "first": "austin",
-    "last": "bryant",
-    "position": "rde"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "eric lee",
-    "first": "eric",
-    "last": "lee",
-    "position": "rde"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "kevin strong",
-    "first": "kevin",
-    "last": "strong",
-    "position": "rde"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "jarrad davis",
-    "first": "jarrad",
-    "last": "davis",
-    "position": "mlb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "jahlani tavai",
-    "first": "jahlani",
-    "last": "tavai",
-    "position": "slb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "jalen reeves-maybin",
-    "first": "jalen",
-    "last": "reeves-maybin",
-    "position": "slb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "malik carney",
-    "first": "malik",
-    "last": "carney",
-    "position": "slb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "garret dooley",
-    "first": "garret",
-    "last": "dooley",
-    "position": "slb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "devon kennard",
-    "first": "devon",
-    "last": "kennard",
-    "position": "wlb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "christian jones",
-    "first": "christian",
-    "last": "jones",
-    "position": "wlb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "steve longa",
-    "first": "steve",
-    "last": "longa",
-    "position": "wlb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "tre lamar",
-    "first": "tre",
-    "last": "lamar",
-    "position": "wlb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "justin coleman",
-    "first": "justin",
-    "last": "coleman",
-    "position": "rcb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "rashaan melvin",
-    "first": "rashaan",
-    "last": "melvin",
-    "position": "rcb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "amani oruwariye",
-    "first": "amani",
-    "last": "oruwariye",
-    "position": "rcb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "andre chachere",
-    "first": "andre",
-    "last": "chachere",
-    "position": "rcb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "mike ford",
-    "first": "mike",
-    "last": "ford",
-    "position": "rcb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "darius slay",
-    "first": "darius",
-    "last": "slay",
-    "position": "lcb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "teez tabor",
-    "first": "teez",
-    "last": "tabor",
-    "position": "lcb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "jamal agnew",
-    "first": "jamal",
-    "last": "agnew",
-    "position": "lcb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "marcus cooper",
-    "first": "marcus",
-    "last": "cooper",
-    "position": "lcb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "dee virgin",
-    "first": "dee",
-    "last": "virgin",
-    "position": "lcb"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "quandre diggs",
-    "first": "quandre",
-    "last": "diggs",
-    "position": "ss"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "will harris",
-    "first": "will",
-    "last": "harris",
-    "position": "ss"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "miles killebrew",
-    "first": "miles",
-    "last": "killebrew",
-    "position": "ss"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "andrew adams",
-    "first": "andrew",
-    "last": "adams",
-    "position": "ss"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "tracy walker",
-    "first": "tracy",
-    "last": "walker",
-    "position": "fs"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "tavon wilson",
-    "first": "tavon",
-    "last": "wilson",
-    "position": "fs"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "charles washington",
-    "first": "charles",
-    "last": "washington",
-    "position": "fs"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "c.j. moore",
-    "first": "c.j.",
-    "last": "moore",
-    "position": "fs"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "sam martin",
-    "first": "sam",
-    "last": "martin",
-    "position": "p"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "ryan santoso",
-    "first": "ryan",
-    "last": "santoso",
-    "position": "p"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "don muhlbach",
-    "first": "don",
-    "last": "muhlbach",
-    "position": "ls"
-  },
-  {
-    "team": "detroit lions",
-    "symbol": "DET",
-    "fullname": "sam martin",
-    "first": "sam",
-    "last": "martin",
-    "position": "h"
+    "fullname": "brandon powell",
+    "first": "brandon",
+    "last": "powell",
+    "position": "wr"
   },
   {
     "team": "detroit lions",
@@ -1424,35 +408,99 @@
     "position": "k"
   },
   {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "lamar jackson",
-    "first": "lamar",
-    "last": "jackson",
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "tom savage",
+    "first": "tom",
+    "last": "savage",
     "position": "qb"
   },
   {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "robert griffin iii",
-    "first": "robert",
-    "last": "griffin",
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "matthew stafford",
+    "first": "matthew",
+    "last": "stafford",
     "position": "qb"
   },
   {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "trace mcsorley",
-    "first": "trace",
-    "last": "mcsorley",
-    "position": "qb"
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "logan thomas",
+    "first": "logan",
+    "last": "thomas",
+    "position": "te"
   },
   {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "mark ingram",
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "mark thompson",
     "first": "mark",
-    "last": "ingram",
+    "last": "thompson",
+    "position": "rb"
+  },
+  {
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "austin traylor",
+    "first": "austin",
+    "last": "traylor",
+    "position": "te"
+  },
+  {
+    "team": "detroit lions",
+    "symbol": "DET",
+    "fullname": "zach zenner",
+    "first": "zach",
+    "last": "zenner",
+    "position": "rb"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "mark andrews",
+    "first": "mark",
+    "last": "andrews",
+    "position": "te"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "miles boykin",
+    "first": "miles",
+    "last": "boykin",
+    "position": "wr"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "nick boyle",
+    "first": "nick",
+    "last": "boyle",
+    "position": "te"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "marquise brown",
+    "first": "marquise",
+    "last": "brown",
+    "position": "wr"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "joe callahan",
+    "first": "joe",
+    "last": "callahan",
+    "position": "qb"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "kenneth dixon",
+    "first": "kenneth",
+    "last": "dixon",
     "position": "rb"
   },
   {
@@ -1466,10 +514,42 @@
   {
     "team": "baltimore ravens",
     "symbol": "BAL",
-    "fullname": "kenneth dixon",
-    "first": "kenneth",
-    "last": "dixon",
+    "fullname": "tyler ervin",
+    "first": "tyler",
+    "last": "ervin",
     "position": "rb"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "christopher ezeala",
+    "first": "christopher",
+    "last": "ezeala",
+    "position": "rb"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "michael floyd",
+    "first": "michael",
+    "last": "floyd",
+    "position": "wr"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "robert griffin iii",
+    "first": "robert",
+    "last": "griffin iii",
+    "position": "qb"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "cole herdman",
+    "first": "cole",
+    "last": "herdman",
+    "position": "te"
   },
   {
     "team": "baltimore ravens",
@@ -1482,49 +562,49 @@
   {
     "team": "baltimore ravens",
     "symbol": "BAL",
-    "fullname": "de'lance turner",
-    "first": "de'lance",
-    "last": "turner",
-    "position": "rb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "tyler ervin",
-    "first": "tyler",
-    "last": "ervin",
-    "position": "rb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "patrick ricard",
-    "first": "patrick",
-    "last": "ricard",
-    "position": "fb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "christopher ezeala",
-    "first": "christopher",
-    "last": "ezeala",
-    "position": "fb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "willie snead",
-    "first": "willie",
-    "last": "snead",
+    "fullname": "joe horn",
+    "first": "joe",
+    "last": "horn",
     "position": "wr"
   },
   {
     "team": "baltimore ravens",
     "symbol": "BAL",
-    "fullname": "marquise brown",
-    "first": "marquise",
-    "last": "brown",
+    "fullname": "hayden hurst",
+    "first": "hayden",
+    "last": "hurst",
+    "position": "te"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "mark ingram",
+    "first": "mark",
+    "last": "ingram",
+    "position": "rb"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "lamar jackson",
+    "first": "lamar",
+    "last": "jackson",
+    "position": "qb"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "trace mcsorley",
+    "first": "trace",
+    "last": "mcsorley",
+    "position": "qb"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "sean modster",
+    "first": "sean",
+    "last": "modster",
     "position": "wr"
   },
   {
@@ -1538,6 +618,14 @@
   {
     "team": "baltimore ravens",
     "symbol": "BAL",
+    "fullname": "matt orzech",
+    "first": "matt",
+    "last": "orzech",
+    "position": "te"
+  },
+  {
+    "team": "baltimore ravens",
+    "symbol": "BAL",
     "fullname": "seth roberts",
     "first": "seth",
     "last": "roberts",
@@ -1546,26 +634,10 @@
   {
     "team": "baltimore ravens",
     "symbol": "BAL",
-    "fullname": "miles boykin",
-    "first": "miles",
-    "last": "boykin",
-    "position": "wr"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "michael floyd",
-    "first": "michael",
-    "last": "floyd",
-    "position": "wr"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "jordan lasley",
-    "first": "jordan",
-    "last": "lasley",
-    "position": "wr"
+    "fullname": "charles scarff",
+    "first": "charles",
+    "last": "scarff",
+    "position": "te"
   },
   {
     "team": "baltimore ravens",
@@ -1573,14 +645,6 @@
     "fullname": "jaleel scott",
     "first": "jaleel",
     "last": "scott",
-    "position": "wr"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "quincy adeboyejo",
-    "first": "quincy",
-    "last": "adeboyejo",
     "position": "wr"
   },
   {
@@ -1594,490 +658,10 @@
   {
     "team": "baltimore ravens",
     "symbol": "BAL",
-    "fullname": "antoine wesley",
-    "first": "antoine",
-    "last": "wesley",
-    "position": "wr"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "sean modster",
-    "first": "sean",
-    "last": "modster",
-    "position": "wr"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "mark andrews",
-    "first": "mark",
-    "last": "andrews",
-    "position": "te"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "hayden hurst",
-    "first": "hayden",
-    "last": "hurst",
-    "position": "te"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "nick boyle",
-    "first": "nick",
-    "last": "boyle",
-    "position": "te"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "cole herdman",
-    "first": "cole",
-    "last": "herdman",
-    "position": "te"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "charles scarff",
-    "first": "charles",
-    "last": "scarff",
-    "position": "te"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "ronnie stanley",
-    "first": "ronnie",
-    "last": "stanley",
-    "position": "lt"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "james hurst",
-    "first": "james",
-    "last": "hurst",
-    "position": "lt"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "jermaine eluemunor",
-    "first": "jermaine",
-    "last": "eluemunor",
-    "position": "lt"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "alex lewis",
-    "first": "alex",
-    "last": "lewis",
-    "position": "lg"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "bradley bozeman",
-    "first": "bradley",
-    "last": "bozeman",
-    "position": "lg"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "patrick vahe",
-    "first": "patrick",
-    "last": "vahe",
-    "position": "lg"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "matt skura",
-    "first": "matt",
-    "last": "skura",
-    "position": "c"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "alex lewis",
-    "first": "alex",
-    "last": "lewis",
-    "position": "c"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "marshal yanda",
-    "first": "marshal",
-    "last": "yanda",
-    "position": "rg"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "ben powers",
-    "first": "ben",
-    "last": "powers",
-    "position": "rg"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "orlando brown",
-    "first": "orlando",
-    "last": "brown",
-    "position": "rt"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "james hurst",
-    "first": "james",
-    "last": "hurst",
-    "position": "rt"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "patrick mekari",
-    "first": "patrick",
-    "last": "mekari",
-    "position": "rt"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "chris wormley",
-    "first": "chris",
-    "last": "wormley",
-    "position": "lde"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "zach sieler",
-    "first": "zach",
-    "last": "sieler",
-    "position": "lde"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "gerald willis",
-    "first": "gerald",
-    "last": "willis",
-    "position": "lde"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "michael pierce",
-    "first": "michael",
-    "last": "pierce",
-    "position": "ndt"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "daylon mack",
-    "first": "daylon",
-    "last": "mack",
-    "position": "ndt"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "brandon williams",
-    "first": "brandon",
-    "last": "williams",
-    "position": "rde"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "willie henry",
+    "fullname": "willie snead",
     "first": "willie",
-    "last": "henry",
-    "position": "rde"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "tim williams",
-    "first": "tim",
-    "last": "williams",
-    "position": "slb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "shane ray",
-    "first": "shane",
-    "last": "ray",
-    "position": "slb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "pernell mcphee",
-    "first": "pernell",
-    "last": "mcphee",
-    "position": "slb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "matthew thomas",
-    "first": "matthew",
-    "last": "thomas",
-    "position": "slb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "markus jones",
-    "first": "markus",
-    "last": "jones",
-    "position": "slb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "matt judon",
-    "first": "matt",
-    "last": "judon",
-    "position": "wlb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "tyus bowser",
-    "first": "tyus",
-    "last": "bowser",
-    "position": "wlb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "jaylon ferguson",
-    "first": "jaylon",
-    "last": "ferguson",
-    "position": "wlb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "silas stewart",
-    "first": "silas",
-    "last": "stewart",
-    "position": "wlb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "michael onuoha",
-    "first": "michael",
-    "last": "onuoha",
-    "position": "wlb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "jimmy smith",
-    "first": "jimmy",
-    "last": "smith",
-    "position": "rcb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "brandon carr",
-    "first": "brandon",
-    "last": "carr",
-    "position": "rcb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "cyrus jones",
-    "first": "cyrus",
-    "last": "jones",
-    "position": "rcb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "stanley jean-baptiste",
-    "first": "stanley",
-    "last": "jean-baptiste",
-    "position": "rcb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "marlon humphrey",
-    "first": "marlon",
-    "last": "humphrey",
-    "position": "lcb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "tavon young",
-    "first": "tavon",
-    "last": "young",
-    "position": "lcb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "anthony averett",
-    "first": "anthony",
-    "last": "averett",
-    "position": "lcb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "justin bethel",
-    "first": "justin",
-    "last": "bethel",
-    "position": "lcb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "maurice canady",
-    "first": "maurice",
-    "last": "canady",
-    "position": "lcb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "terrell bonds",
-    "first": "terrell",
-    "last": "bonds",
-    "position": "lcb"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "tony jefferson",
-    "first": "tony",
-    "last": "jefferson",
-    "position": "ss"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "chuck clark",
-    "first": "chuck",
-    "last": "clark",
-    "position": "ss"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "deshon elliott",
-    "first": "deshon",
-    "last": "elliott",
-    "position": "ss"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "earl thomas",
-    "first": "earl",
-    "last": "thomas",
-    "position": "fs"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "anthony levine",
-    "first": "anthony",
-    "last": "levine",
-    "position": "fs"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "bennett jackson",
-    "first": "bennett",
-    "last": "jackson",
-    "position": "fs"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "sam koch",
-    "first": "sam",
-    "last": "koch",
-    "position": "p"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "kaare vedvik",
-    "first": "kaare",
-    "last": "vedvik",
-    "position": "p"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "morgan cox",
-    "first": "morgan",
-    "last": "cox",
-    "position": "ls"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "sam koch",
-    "first": "sam",
-    "last": "koch",
-    "position": "h"
-  },
-  {
-    "team": "baltimore ravens",
-    "symbol": "BAL",
-    "fullname": "robert griffin iii",
-    "first": "robert",
-    "last": "griffin",
-    "position": "h"
+    "last": "snead",
+    "position": "wr"
   },
   {
     "team": "baltimore ravens",
@@ -2090,90 +674,18 @@
   {
     "team": "baltimore ravens",
     "symbol": "BAL",
-    "fullname": "kaare vedvik",
-    "first": "kaare",
-    "last": "vedvik",
-    "position": "k"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "aaron rodgers",
-    "first": "aaron",
-    "last": "rodgers",
-    "position": "qb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "deshone kizer",
-    "first": "deshone",
-    "last": "kizer",
-    "position": "qb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "tim boyle",
-    "first": "tim",
-    "last": "boyle",
-    "position": "qb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "manny wilkins",
-    "first": "manny",
-    "last": "wilkins",
-    "position": "qb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "aaron jones",
-    "first": "aaron",
-    "last": "jones",
+    "fullname": "de'lance turner",
+    "first": "de'lance",
+    "last": "turner",
     "position": "rb"
   },
   {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "jamaal williams",
-    "first": "jamaal",
-    "last": "williams",
-    "position": "rb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "dexter williams",
-    "first": "dexter",
-    "last": "williams",
-    "position": "rb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "tra carson",
-    "first": "tra",
-    "last": "carson",
-    "position": "rb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "danny vitale",
-    "first": "danny",
-    "last": "vitale",
-    "position": "fb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "malcolm johnson",
-    "first": "malcolm",
-    "last": "johnson",
-    "position": "fb"
+    "team": "baltimore ravens",
+    "symbol": "BAL",
+    "fullname": "antoine wesley",
+    "first": "antoine",
+    "last": "wesley",
+    "position": "wr"
   },
   {
     "team": "green bay packers",
@@ -2181,14 +693,6 @@
     "fullname": "davante adams",
     "first": "davante",
     "last": "adams",
-    "position": "wr"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "marquez valdes-scantling",
-    "first": "marquez",
-    "last": "valdes-scantling",
     "position": "wr"
   },
   {
@@ -2202,25 +706,41 @@
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "equanimeous st. brown",
-    "first": "equanimeous",
-    "last": "st.",
-    "position": "wr"
+    "fullname": "evan baylis",
+    "first": "evan",
+    "last": "baylis",
+    "position": "te"
   },
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "jake kumerow",
-    "first": "jake",
-    "last": "kumerow",
-    "position": "wr"
+    "fullname": "tim boyle",
+    "first": "tim",
+    "last": "boyle",
+    "position": "qb"
   },
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "j'mon moore",
-    "first": "j'mon",
-    "last": "moore",
+    "fullname": "tra carson",
+    "first": "tra",
+    "last": "carson",
+    "position": "rb"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "mason crosby",
+    "first": "mason",
+    "last": "crosby",
+    "position": "k"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "jawill davis",
+    "first": "jawill",
+    "last": "davis",
     "position": "wr"
   },
   {
@@ -2234,34 +754,26 @@
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "allen lazard",
-    "first": "allen",
-    "last": "lazard",
+    "fullname": "kabion ento",
+    "first": "kabion",
+    "last": "ento",
     "position": "wr"
   },
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "jawill davis",
-    "first": "jawill",
-    "last": "davis",
-    "position": "wr"
+    "fullname": "sam ficken",
+    "first": "sam",
+    "last": "ficken",
+    "position": "k"
   },
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "teo redding",
-    "first": "teo",
-    "last": "redding",
-    "position": "wr"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "darrius shepherd",
-    "first": "darrius",
-    "last": "shepherd",
-    "position": "wr"
+    "fullname": "keith ford",
+    "first": "keith",
+    "last": "ford",
+    "position": "rb"
   },
   {
     "team": "green bay packers",
@@ -2274,10 +786,50 @@
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "jace sternberger",
-    "first": "jace",
-    "last": "sternberger",
+    "fullname": "darrin hall",
+    "first": "darrin",
+    "last": "hall",
+    "position": "rb"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "malcolm johnson",
+    "first": "malcolm",
+    "last": "johnson",
     "position": "te"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "aaron jones",
+    "first": "aaron",
+    "last": "jones",
+    "position": "rb"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "deshone kizer",
+    "first": "deshone",
+    "last": "kizer",
+    "position": "qb"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "jake kumerow",
+    "first": "jake",
+    "last": "kumerow",
+    "position": "wr"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "allen lazard",
+    "first": "allen",
+    "last": "lazard",
+    "position": "wr"
   },
   {
     "team": "green bay packers",
@@ -2285,14 +837,6 @@
     "fullname": "marcedes lewis",
     "first": "marcedes",
     "last": "lewis",
-    "position": "te"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "robert tonyan",
-    "first": "robert",
-    "last": "tonyan",
     "position": "te"
   },
   {
@@ -2306,529 +850,105 @@
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "evan baylis",
-    "first": "evan",
-    "last": "baylis",
+    "fullname": "j'mon moore",
+    "first": "j'mon",
+    "last": "moore",
+    "position": "wr"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "teo redding",
+    "first": "teo",
+    "last": "redding",
+    "position": "wr"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "aaron rodgers",
+    "first": "aaron",
+    "last": "rodgers",
+    "position": "qb"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "darrius shepherd",
+    "first": "darrius",
+    "last": "shepherd",
+    "position": "wr"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "equanimeous st. brown",
+    "first": "equanimeous",
+    "last": "st. brown",
+    "position": "wr"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "jace sternberger",
+    "first": "jace",
+    "last": "sternberger",
     "position": "te"
   },
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "david bakhtiari",
-    "first": "david",
-    "last": "bakhtiari",
-    "position": "lt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "jason spriggs",
-    "first": "jason",
-    "last": "spriggs",
-    "position": "lt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "yosh nijman",
-    "first": "yosh",
-    "last": "nijman",
-    "position": "lt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "lane taylor",
-    "first": "lane",
+    "fullname": "malik taylor",
+    "first": "malik",
     "last": "taylor",
-    "position": "lg"
+    "position": "wr"
   },
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "elgton jenkins",
-    "first": "elgton",
-    "last": "jenkins",
-    "position": "lg"
+    "fullname": "robert tonyan jr.",
+    "first": "robert",
+    "last": "tonyan jr.",
+    "position": "wr"
   },
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "lucas patrick",
-    "first": "lucas",
-    "last": "patrick",
-    "position": "lg"
+    "fullname": "marquez valdes-scantling",
+    "first": "marquez",
+    "last": "valdes-scantling",
+    "position": "wr"
   },
   {
     "team": "green bay packers",
     "symbol": "GB",
-    "fullname": "larry williams",
-    "first": "larry",
+    "fullname": "dan vitale",
+    "first": "dan",
+    "last": "vitale",
+    "position": "fb"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "manny wilkins",
+    "first": "manny",
+    "last": "wilkins",
+    "position": "qb"
+  },
+  {
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "dexter williams",
+    "first": "dexter",
     "last": "williams",
-    "position": "lg"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "corey linsley",
-    "first": "corey",
-    "last": "linsley",
-    "position": "c"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "elgton jenkins",
-    "first": "elgton",
-    "last": "jenkins",
-    "position": "c"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "billy turner",
-    "first": "billy",
-    "last": "turner",
-    "position": "rg"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "cole madison",
-    "first": "cole",
-    "last": "madison",
-    "position": "rg"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "adam pankey",
-    "first": "adam",
-    "last": "pankey",
-    "position": "rg"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "bryan bulaga",
-    "first": "bryan",
-    "last": "bulaga",
-    "position": "rt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "justin mccray",
-    "first": "justin",
-    "last": "mccray",
-    "position": "rt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "dean lowry",
-    "first": "dean",
-    "last": "lowry",
-    "position": "lde"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "james looney",
-    "first": "james",
-    "last": "looney",
-    "position": "lde"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "eric cotton",
-    "first": "eric",
-    "last": "cotton",
-    "position": "lde"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "kenny clark",
-    "first": "kenny",
-    "last": "clark",
-    "position": "ndt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "kingsley keke",
-    "first": "kingsley",
-    "last": "keke",
-    "position": "ndt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "tyler lancaster",
-    "first": "tyler",
-    "last": "lancaster",
-    "position": "ndt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "deon simon",
-    "first": "deon",
-    "last": "simon",
-    "position": "ndt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "mike daniels",
-    "first": "mike",
-    "last": "daniels",
-    "position": "rde"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "montravius adams",
-    "first": "montravius",
-    "last": "adams",
-    "position": "rde"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "fadol brown",
-    "first": "fadol",
-    "last": "brown",
-    "position": "rde"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "za'darius smith",
-    "first": "za'darius",
-    "last": "smith",
-    "position": "slb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "kyler fackrell",
-    "first": "kyler",
-    "last": "fackrell",
-    "position": "slb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "kendall donnerson",
-    "first": "kendall",
-    "last": "donnerson",
-    "position": "slb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "greg roberts",
-    "first": "greg",
-    "last": "roberts",
-    "position": "slb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "preston smith",
-    "first": "preston",
-    "last": "smith",
-    "position": "wlb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "rashan gary",
-    "first": "rashan",
-    "last": "gary",
-    "position": "wlb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "reggie gilbert",
-    "first": "reggie",
-    "last": "gilbert",
-    "position": "wlb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "brady sheldon",
-    "first": "brady",
-    "last": "sheldon",
-    "position": "wlb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "kevin king",
-    "first": "kevin",
-    "last": "king",
-    "position": "rcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "josh jackson",
-    "first": "josh",
-    "last": "jackson",
-    "position": "rcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "will redmond",
-    "first": "will",
-    "last": "redmond",
-    "position": "rcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "natrell jamerson",
-    "first": "natrell",
-    "last": "jamerson",
-    "position": "rcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "chandon sullivan",
-    "first": "chandon",
-    "last": "sullivan",
-    "position": "rcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "javien hamilton",
-    "first": "javien",
-    "last": "hamilton",
-    "position": "rcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "jaire alexander",
-    "first": "jaire",
-    "last": "alexander",
-    "position": "lcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "tramon williams",
-    "first": "tramon",
-    "last": "williams",
-    "position": "lcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "tony brown",
-    "first": "tony",
-    "last": "brown",
-    "position": "lcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "ka'dar hollman",
-    "first": "ka'dar",
-    "last": "hollman",
-    "position": "lcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "kabion ento",
-    "first": "kabion",
-    "last": "ento",
-    "position": "lcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "nydair rouse",
-    "first": "nydair",
-    "last": "rouse",
-    "position": "lcb"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "adrian amos",
-    "first": "adrian",
-    "last": "amos",
-    "position": "ss"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "raven greene",
-    "first": "raven",
-    "last": "greene",
-    "position": "ss"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "tray matthews",
-    "first": "tray",
-    "last": "matthews",
-    "position": "ss"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "darnell savage",
-    "first": "darnell",
-    "last": "savage",
-    "position": "fs"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "josh jones",
-    "first": "josh",
-    "last": "jones",
-    "position": "fs"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "mike tyson",
-    "first": "mike",
-    "last": "tyson",
-    "position": "fs"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "j.k. scott",
-    "first": "j.k.",
-    "last": "scott",
-    "position": "p"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "hunter bradley",
-    "first": "hunter",
-    "last": "bradley",
-    "position": "ls"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "j.k. scott",
-    "first": "j.k.",
-    "last": "scott",
-    "position": "h"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "mason crosby",
-    "first": "mason",
-    "last": "crosby",
-    "position": "k"
-  },
-  {
-    "team": "green bay packers",
-    "symbol": "GB",
-    "fullname": "sam ficken",
-    "first": "sam",
-    "last": "ficken",
-    "position": "k"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "kirk cousins",
-    "first": "kirk",
-    "last": "cousins",
-    "position": "qb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "sean mannion",
-    "first": "sean",
-    "last": "mannion",
-    "position": "qb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "kyle sloter",
-    "first": "kyle",
-    "last": "sloter",
-    "position": "qb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "jake browning",
-    "first": "jake",
-    "last": "browning",
-    "position": "qb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "dalvin cook",
-    "first": "dalvin",
-    "last": "cook",
     "position": "rb"
   },
   {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "alexander mattison",
-    "first": "alexander",
-    "last": "mattison",
-    "position": "rb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "mike boone",
-    "first": "mike",
-    "last": "boone",
+    "team": "green bay packers",
+    "symbol": "GB",
+    "fullname": "jamaal williams",
+    "first": "jamaal",
+    "last": "williams",
     "position": "rb"
   },
   {
@@ -2842,25 +962,81 @@
   {
     "team": "minnesota vikings",
     "symbol": "MIN",
-    "fullname": "roc thomas",
-    "first": "roc",
-    "last": "thomas",
+    "fullname": "jeff badet",
+    "first": "jeff",
+    "last": "badet",
+    "position": "wr"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "dan bailey",
+    "first": "dan",
+    "last": "bailey",
+    "position": "k"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "chad beebe",
+    "first": "chad",
+    "last": "beebe",
+    "position": "wr"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "khari blasingame",
+    "first": "khari",
+    "last": "blasingame",
     "position": "rb"
   },
   {
     "team": "minnesota vikings",
     "symbol": "MIN",
-    "fullname": "c.j. ham",
-    "first": "c.j.",
-    "last": "ham",
-    "position": "fb"
+    "fullname": "michael boone",
+    "first": "michael",
+    "last": "boone",
+    "position": "rb"
   },
   {
     "team": "minnesota vikings",
     "symbol": "MIN",
-    "fullname": "adam thielen",
-    "first": "adam",
-    "last": "thielen",
+    "fullname": "jake browning",
+    "first": "jake",
+    "last": "browning",
+    "position": "qb"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "tyler conklin",
+    "first": "tyler",
+    "last": "conklin",
+    "position": "te"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "dalvin cook",
+    "first": "dalvin",
+    "last": "cook",
+    "position": "rb"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "kirk cousins",
+    "first": "kirk",
+    "last": "cousins",
+    "position": "qb"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "davion davis",
+    "first": "davion",
+    "last": "davis",
     "position": "wr"
   },
   {
@@ -2874,6 +1050,110 @@
   {
     "team": "minnesota vikings",
     "symbol": "MIN",
+    "fullname": "brandon dillon",
+    "first": "brandon",
+    "last": "dillon",
+    "position": "te"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "cj ham",
+    "first": "cj",
+    "last": "ham",
+    "position": "rb"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "de'angelo henderson",
+    "first": "de'angelo",
+    "last": "henderson",
+    "position": "rb"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "cole hikutini",
+    "first": "cole",
+    "last": "hikutini",
+    "position": "te"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "alexander hollins",
+    "first": "alexander",
+    "last": "hollins",
+    "position": "wr"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "olabisi johnson",
+    "first": "olabisi",
+    "last": "johnson",
+    "position": "wr"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "sean mannion",
+    "first": "sean",
+    "last": "mannion",
+    "position": "qb"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "alexander mattison",
+    "first": "alexander",
+    "last": "mattison",
+    "position": "rb"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "dillon mitchell",
+    "first": "dillon",
+    "last": "mitchell",
+    "position": "wr"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "david morgan ii",
+    "first": "david",
+    "last": "morgan ii",
+    "position": "te"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "kyle rudolph",
+    "first": "kyle",
+    "last": "rudolph",
+    "position": "te"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "kyle sloter",
+    "first": "kyle",
+    "last": "sloter",
+    "position": "qb"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
+    "fullname": "irv smith jr.",
+    "first": "irv",
+    "last": "smith jr.",
+    "position": "te"
+  },
+  {
+    "team": "minnesota vikings",
+    "symbol": "MIN",
     "fullname": "jordan taylor",
     "first": "jordan",
     "last": "taylor",
@@ -2882,9 +1162,9 @@
   {
     "team": "minnesota vikings",
     "symbol": "MIN",
-    "fullname": "chad beebe",
-    "first": "chad",
-    "last": "beebe",
+    "fullname": "adam thielen",
+    "first": "adam",
+    "last": "thielen",
     "position": "wr"
   },
   {
@@ -2898,18 +1178,10 @@
   {
     "team": "minnesota vikings",
     "symbol": "MIN",
-    "fullname": "dillon mitchell",
-    "first": "dillon",
-    "last": "mitchell",
-    "position": "wr"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "bisi johnson",
-    "first": "bisi",
-    "last": "johnson",
-    "position": "wr"
+    "fullname": "matt wile",
+    "first": "matt",
+    "last": "wile",
+    "position": "k"
   },
   {
     "team": "minnesota vikings",
@@ -2920,588 +1192,12 @@
     "position": "wr"
   },
   {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "jeff badet",
-    "first": "jeff",
-    "last": "badet",
-    "position": "wr"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "davion davis",
-    "first": "davion",
-    "last": "davis",
-    "position": "wr"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "alexander hollins",
-    "first": "alexander",
-    "last": "hollins",
-    "position": "wr"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "kyle rudolph",
-    "first": "kyle",
-    "last": "rudolph",
-    "position": "te"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "irv smith",
-    "first": "irv",
-    "last": "smith",
-    "position": "te"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "david morgan",
-    "first": "david",
-    "last": "morgan",
-    "position": "te"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "tyler conklin",
-    "first": "tyler",
-    "last": "conklin",
-    "position": "te"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "cole hikutini",
-    "first": "cole",
-    "last": "hikutini",
-    "position": "te"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "brandon dillon",
-    "first": "brandon",
-    "last": "dillon",
-    "position": "te"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "riley reiff",
-    "first": "riley",
-    "last": "reiff",
-    "position": "lt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "pat elflein",
-    "first": "pat",
-    "last": "elflein",
-    "position": "lg"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "danny isidora",
-    "first": "danny",
-    "last": "isidora",
-    "position": "lg"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "aviante collins",
-    "first": "aviante",
-    "last": "collins",
-    "position": "lg"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "garrett bradbury",
-    "first": "garrett",
-    "last": "bradbury",
-    "position": "c"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "brett jones",
-    "first": "brett",
-    "last": "jones",
-    "position": "c"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "cornelius edison",
-    "first": "cornelius",
-    "last": "edison",
-    "position": "c"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "john keenoy",
-    "first": "john",
-    "last": "keenoy",
-    "position": "c"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "josh kline",
-    "first": "josh",
-    "last": "kline",
-    "position": "rg"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "dru samia",
-    "first": "dru",
-    "last": "samia",
-    "position": "rg"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "dakota dozier",
-    "first": "dakota",
-    "last": "dozier",
-    "position": "rg"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "brian o'neill",
-    "first": "brian",
-    "last": "o'neill",
-    "position": "rt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "rashod hill",
-    "first": "rashod",
-    "last": "hill",
-    "position": "rt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "linval joseph",
-    "first": "linval",
-    "last": "joseph",
-    "position": "ldt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "jaleel johnson",
-    "first": "jaleel",
-    "last": "johnson",
-    "position": "ldt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "hercules mata'afa",
-    "first": "hercules",
-    "last": "mata'afa",
-    "position": "ldt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "curtis cothran",
-    "first": "curtis",
-    "last": "cothran",
-    "position": "ldt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "danielle hunter",
-    "first": "danielle",
-    "last": "hunter",
-    "position": "lde"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "tashawn bower",
-    "first": "tashawn",
-    "last": "bower",
-    "position": "lde"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "ifeadi odenigbo",
-    "first": "ifeadi",
-    "last": "odenigbo",
-    "position": "lde"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "stacy keely",
-    "first": "stacy",
-    "last": "keely",
-    "position": "lde"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "anree saint-amour",
-    "first": "anree",
-    "last": "saint-amour",
-    "position": "lde"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "shamar stephen",
-    "first": "shamar",
-    "last": "stephen",
-    "position": "rdt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "jalyn holmes",
-    "first": "jalyn",
-    "last": "holmes",
-    "position": "rdt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "armon watts",
-    "first": "armon",
-    "last": "watts",
-    "position": "rdt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "tito odenigbo",
-    "first": "tito",
-    "last": "odenigbo",
-    "position": "rdt"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "everson griffen",
-    "first": "everson",
-    "last": "griffen",
-    "position": "rde"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "stephen weatherly",
-    "first": "stephen",
-    "last": "weatherly",
-    "position": "rde"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "ade aruna",
-    "first": "ade",
-    "last": "aruna",
-    "position": "rde"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "karter schult",
-    "first": "karter",
-    "last": "schult",
-    "position": "rde"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "eric kendricks",
-    "first": "eric",
-    "last": "kendricks",
-    "position": "mlb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "eric wilson",
-    "first": "eric",
-    "last": "wilson",
-    "position": "mlb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "cameron smith",
-    "first": "cameron",
-    "last": "smith",
-    "position": "mlb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "greer martini",
-    "first": "greer",
-    "last": "martini",
-    "position": "mlb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "anthony barr",
-    "first": "anthony",
-    "last": "barr",
-    "position": "slb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "devante downs",
-    "first": "devante",
-    "last": "downs",
-    "position": "slb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "ben gedeon",
+    "team": "chicago bears",
+    "symbol": "CHI",
+    "fullname": "ben braunecker",
     "first": "ben",
-    "last": "gedeon",
-    "position": "wlb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "kentrell brothers",
-    "first": "kentrell",
-    "last": "brothers",
-    "position": "wlb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "reshard cliett",
-    "first": "reshard",
-    "last": "cliett",
-    "position": "wlb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "xavier rhodes",
-    "first": "xavier",
-    "last": "rhodes",
-    "position": "rcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "mackensie alexander",
-    "first": "mackensie",
-    "last": "alexander",
-    "position": "rcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "craig james",
-    "first": "craig",
-    "last": "james",
-    "position": "rcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "holton hill",
-    "first": "holton",
-    "last": "hill",
-    "position": "rcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "isaiah wharton",
-    "first": "isaiah",
-    "last": "wharton",
-    "position": "rcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "trae waynes",
-    "first": "trae",
-    "last": "waynes",
-    "position": "lcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "mike hughes",
-    "first": "mike",
-    "last": "hughes",
-    "position": "lcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "kris boyd",
-    "first": "kris",
-    "last": "boyd",
-    "position": "lcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "duke thomas",
-    "first": "duke",
-    "last": "thomas",
-    "position": "lcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "nathan meadors",
-    "first": "nathan",
-    "last": "meadors",
-    "position": "lcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "terrence alexander",
-    "first": "terrence",
-    "last": "alexander",
-    "position": "lcb"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "anthony harris",
-    "first": "anthony",
-    "last": "harris",
-    "position": "ss"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "jayron kearse",
-    "first": "jayron",
-    "last": "kearse",
-    "position": "ss"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "harrison smith",
-    "first": "harrison",
-    "last": "smith",
-    "position": "fs"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "derron smith",
-    "first": "derron",
-    "last": "smith",
-    "position": "fs"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "marcus epps",
-    "first": "marcus",
-    "last": "epps",
-    "position": "fs"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "micah abernathy",
-    "first": "micah",
-    "last": "abernathy",
-    "position": "fs"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "matt wile",
-    "first": "matt",
-    "last": "wile",
-    "position": "p"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "kevin mcdermott",
-    "first": "kevin",
-    "last": "mcdermott",
-    "position": "ls"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "austin cutting",
-    "first": "austin",
-    "last": "cutting",
-    "position": "ls"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "matt wile",
-    "first": "matt",
-    "last": "wile",
-    "position": "h"
-  },
-  {
-    "team": "minnesota vikings",
-    "symbol": "MIN",
-    "fullname": "dan bailey",
-    "first": "dan",
-    "last": "bailey",
-    "position": "k"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "mitchell trubisky",
-    "first": "mitchell",
-    "last": "trubisky",
-    "position": "qb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "chase daniel",
-    "first": "chase",
-    "last": "daniel",
-    "position": "qb"
+    "last": "braunecker",
+    "position": "te"
   },
   {
     "team": "chicago bears",
@@ -3514,6 +1210,22 @@
   {
     "team": "chicago bears",
     "symbol": "CHI",
+    "fullname": "ian bunting",
+    "first": "ian",
+    "last": "bunting",
+    "position": "te"
+  },
+  {
+    "team": "chicago bears",
+    "symbol": "CHI",
+    "fullname": "trey burton",
+    "first": "trey",
+    "last": "burton",
+    "position": "te"
+  },
+  {
+    "team": "chicago bears",
+    "symbol": "CHI",
     "fullname": "tarik cohen",
     "first": "tarik",
     "last": "cohen",
@@ -3522,10 +1234,10 @@
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "david montgomery",
-    "first": "david",
-    "last": "montgomery",
-    "position": "rb"
+    "fullname": "chase daniel",
+    "first": "chase",
+    "last": "daniel",
+    "position": "qb"
   },
   {
     "team": "chicago bears",
@@ -3538,34 +1250,10 @@
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "kerrith whyte",
-    "first": "kerrith",
-    "last": "whyte",
-    "position": "rb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "ryan nall",
-    "first": "ryan",
-    "last": "nall",
-    "position": "rb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "fb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "allen robinson",
-    "first": "allen",
-    "last": "robinson",
-    "position": "wr"
+    "fullname": "elliott fry",
+    "first": "elliott",
+    "last": "fry",
+    "position": "k"
   },
   {
     "team": "chicago bears",
@@ -3573,62 +1261,6 @@
     "fullname": "taylor gabriel",
     "first": "taylor",
     "last": "gabriel",
-    "position": "wr"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "anthony miller",
-    "first": "anthony",
-    "last": "miller",
-    "position": "wr"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "cordarrelle patterson",
-    "first": "cordarrelle",
-    "last": "patterson",
-    "position": "wr"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "riley ridley",
-    "first": "riley",
-    "last": "ridley",
-    "position": "wr"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "javon wims",
-    "first": "javon",
-    "last": "wims",
-    "position": "wr"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "marvin hall",
-    "first": "marvin",
-    "last": "hall",
-    "position": "wr"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "emanuel hall",
-    "first": "emanuel",
-    "last": "hall",
-    "position": "wr"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "taquan mizzell",
-    "first": "taquan",
-    "last": "mizzell",
     "position": "wr"
   },
   {
@@ -3642,10 +1274,26 @@
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "jordan williams-lambert",
-    "first": "jordan",
-    "last": "williams-lambert",
+    "fullname": "emanuel hall",
+    "first": "emanuel",
+    "last": "hall",
     "position": "wr"
+  },
+  {
+    "team": "chicago bears",
+    "symbol": "CHI",
+    "fullname": "marvin hall",
+    "first": "marvin",
+    "last": "hall",
+    "position": "wr"
+  },
+  {
+    "team": "chicago bears",
+    "symbol": "CHI",
+    "fullname": "jesper horsted",
+    "first": "jesper",
+    "last": "horsted",
+    "position": "te"
   },
   {
     "team": "chicago bears",
@@ -3658,26 +1306,50 @@
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "trey burton",
-    "first": "trey",
-    "last": "burton",
-    "position": "te"
+    "fullname": "anthony miller",
+    "first": "anthony",
+    "last": "miller",
+    "position": "wr"
   },
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "adam shaheen",
-    "first": "adam",
-    "last": "shaheen",
-    "position": "te"
+    "fullname": "taquan mizzell",
+    "first": "taquan",
+    "last": "mizzell",
+    "position": "rb"
   },
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "ben braunecker",
-    "first": "ben",
-    "last": "braunecker",
-    "position": "te"
+    "fullname": "david montgomery",
+    "first": "david",
+    "last": "montgomery",
+    "position": "rb"
+  },
+  {
+    "team": "chicago bears",
+    "symbol": "CHI",
+    "fullname": "ryan nall",
+    "first": "ryan",
+    "last": "nall",
+    "position": "rb"
+  },
+  {
+    "team": "chicago bears",
+    "symbol": "CHI",
+    "fullname": "cordarrelle patterson",
+    "first": "cordarrelle",
+    "last": "patterson",
+    "position": "wr"
+  },
+  {
+    "team": "chicago bears",
+    "symbol": "CHI",
+    "fullname": "eddy pineiro",
+    "first": "eddy",
+    "last": "pineiro",
+    "position": "k"
   },
   {
     "team": "chicago bears",
@@ -3685,22 +1357,6 @@
     "fullname": "dax raymond",
     "first": "dax",
     "last": "raymond",
-    "position": "te"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "ian bunting",
-    "first": "ian",
-    "last": "bunting",
-    "position": "te"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "bradley sowell",
-    "first": "bradley",
-    "last": "sowell",
     "position": "te"
   },
   {
@@ -3714,498 +1370,74 @@
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "jesper horsted",
-    "first": "jesper",
-    "last": "horsted",
+    "fullname": "riley ridley",
+    "first": "riley",
+    "last": "ridley",
+    "position": "wr"
+  },
+  {
+    "team": "chicago bears",
+    "symbol": "CHI",
+    "fullname": "allen robinson",
+    "first": "allen",
+    "last": "robinson",
+    "position": "wr"
+  },
+  {
+    "team": "chicago bears",
+    "symbol": "CHI",
+    "fullname": "adam shaheen",
+    "first": "adam",
+    "last": "shaheen",
     "position": "te"
   },
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "charles leno jr.",
-    "first": "charles",
-    "last": "leno",
-    "position": "lt"
+    "fullname": "bradley sowell",
+    "first": "bradley",
+    "last": "sowell",
+    "position": "te"
   },
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "t.j. clemmings",
-    "first": "t.j.",
-    "last": "clemmings",
-    "position": "lt"
+    "fullname": "mitch trubisky",
+    "first": "mitch",
+    "last": "trubisky",
+    "position": "qb"
   },
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "james daniels",
-    "first": "james",
-    "last": "daniels",
-    "position": "lg"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "ted larsen",
-    "first": "ted",
-    "last": "larsen",
-    "position": "lg"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "alex bars",
-    "first": "alex",
-    "last": "bars",
-    "position": "lg"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "marquez tucker",
-    "first": "marquez",
-    "last": "tucker",
-    "position": "lg"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "cody whitehair",
-    "first": "cody",
-    "last": "whitehair",
-    "position": "c"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "sam mustipher",
-    "first": "sam",
-    "last": "mustipher",
-    "position": "c"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "kyle long",
-    "first": "kyle",
-    "last": "long",
-    "position": "rg"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "joe lowery",
+    "fullname": "joe walker",
     "first": "joe",
-    "last": "lowery",
-    "position": "rg"
+    "last": "walker",
+    "position": "wr"
   },
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "jordan mccray",
+    "fullname": "kerrith whyte jr.",
+    "first": "kerrith",
+    "last": "whyte jr.",
+    "position": "rb"
+  },
+  {
+    "team": "chicago bears",
+    "symbol": "CHI",
+    "fullname": "jordan williams-lambert",
     "first": "jordan",
-    "last": "mccray",
-    "position": "rg"
+    "last": "williams-lambert",
+    "position": "wr"
   },
   {
     "team": "chicago bears",
     "symbol": "CHI",
-    "fullname": "bobby massie",
-    "first": "bobby",
-    "last": "massie",
-    "position": "rt"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "rashaad coward",
-    "first": "rashaad",
-    "last": "coward",
-    "position": "rt"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "cornelius lucas",
-    "first": "cornelius",
-    "last": "lucas",
-    "position": "rt"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "akiem hicks",
-    "first": "akiem",
-    "last": "hicks",
-    "position": "lde"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "bilal nichols",
-    "first": "bilal",
-    "last": "nichols",
-    "position": "lde"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "nick williams",
-    "first": "nick",
-    "last": "williams",
-    "position": "lde"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "daryle banfield",
-    "first": "daryle",
-    "last": "banfield",
-    "position": "lde"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "eddie goldman",
-    "first": "eddie",
-    "last": "goldman",
-    "position": "ndt"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "abdullah anderson",
-    "first": "abdullah",
-    "last": "anderson",
-    "position": "ndt"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "roy robertson-harris",
-    "first": "roy",
-    "last": "robertson-harris",
-    "position": "rde"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "jonathan bullard",
-    "first": "jonathan",
-    "last": "bullard",
-    "position": "rde"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "jonathan harris",
-    "first": "jonathan",
-    "last": "harris",
-    "position": "rde"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "jalen dalton",
-    "first": "jalen",
-    "last": "dalton",
-    "position": "rde"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "leonard floyd",
-    "first": "leonard",
-    "last": "floyd",
-    "position": "slb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "aaron lynch",
-    "first": "aaron",
-    "last": "lynch",
-    "position": "slb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "kylie fitts",
-    "first": "kylie",
-    "last": "fitts",
-    "position": "slb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "khalil mack",
-    "first": "khalil",
-    "last": "mack",
-    "position": "wlb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "isaiah irving",
-    "first": "isaiah",
-    "last": "irving",
-    "position": "wlb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "james vaughters",
-    "first": "james",
-    "last": "vaughters",
-    "position": "wlb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "matt betts",
-    "first": "matt",
-    "last": "betts",
-    "position": "wlb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "chuck harris",
-    "first": "chuck",
-    "last": "harris",
-    "position": "wlb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "kyle fuller",
-    "first": "kyle",
-    "last": "fuller",
-    "position": "rcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "sherrick mcmanis",
-    "first": "sherrick",
-    "last": "mcmanis",
-    "position": "rcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "michael joseph",
-    "first": "michael",
-    "last": "joseph",
-    "position": "rcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "stephen denmark",
-    "first": "stephen",
-    "last": "denmark",
-    "position": "rcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "josh simmons",
-    "first": "josh",
-    "last": "simmons",
-    "position": "rcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "rashard fant",
-    "first": "rashard",
-    "last": "fant",
-    "position": "rcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "prince amukamara",
-    "first": "prince",
-    "last": "amukamara",
-    "position": "lcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "buster skrine",
-    "first": "buster",
-    "last": "skrine",
-    "position": "lcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "kevin toliver",
-    "first": "kevin",
-    "last": "toliver",
-    "position": "lcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "duke shelley",
-    "first": "duke",
-    "last": "shelley",
-    "position": "lcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "clifton duck",
-    "first": "clifton",
-    "last": "duck",
-    "position": "lcb"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "ha ha clinton-dix",
-    "first": "ha",
-    "last": "ha",
-    "position": "ss"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "deandre houston-carson",
-    "first": "deandre",
-    "last": "houston-carson",
-    "position": "ss"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "doyin jibowu",
-    "first": "doyin",
-    "last": "jibowu",
-    "position": "ss"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "eddie jackson",
-    "first": "eddie",
-    "last": "jackson",
-    "position": "fs"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "deon bush",
-    "first": "deon",
-    "last": "bush",
-    "position": "fs"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "jonathon mincy",
-    "first": "jonathon",
-    "last": "mincy",
-    "position": "fs"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "pat o'donnell",
-    "first": "pat",
-    "last": "o'donnell",
-    "position": "p"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "patrick scales",
-    "first": "patrick",
-    "last": "scales",
-    "position": "ls"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "john wirtel",
-    "first": "john",
-    "last": "wirtel",
-    "position": "ls"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "pat o'donnell",
-    "first": "pat",
-    "last": "o'donnell",
-    "position": "h"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "chase daniel",
-    "first": "chase",
-    "last": "daniel",
-    "position": "h"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "eddy pineiro",
-    "first": "eddy",
-    "last": "pineiro",
-    "position": "k"
-  },
-  {
-    "team": "chicago bears",
-    "symbol": "CHI",
-    "fullname": "elliott fry",
-    "first": "elliott",
-    "last": "fry",
-    "position": "k"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "jared goff",
-    "first": "jared",
-    "last": "goff",
-    "position": "qb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "blake bortles",
-    "first": "blake",
-    "last": "bortles",
-    "position": "qb"
+    "fullname": "javon wims",
+    "first": "javon",
+    "last": "wims",
+    "position": "wr"
   },
   {
     "team": "los angeles rams",
@@ -4218,10 +1450,98 @@
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "john wolford",
-    "first": "john",
-    "last": "wolford",
+    "fullname": "alex bachman",
+    "first": "alex",
+    "last": "bachman",
+    "position": "wr"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "kendall blanton",
+    "first": "kendall",
+    "last": "blanton",
+    "position": "te"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "blake bortles",
+    "first": "blake",
+    "last": "bortles",
     "position": "qb"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "romello brooker",
+    "first": "romello",
+    "last": "brooker",
+    "position": "te"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "keenen brown",
+    "first": "keenen",
+    "last": "brown",
+    "position": "te"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "malcolm brown",
+    "first": "malcolm",
+    "last": "brown",
+    "position": "rb"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "matt colburn",
+    "first": "matt",
+    "last": "colburn",
+    "position": "rb"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "brandin cooks",
+    "first": "brandin",
+    "last": "cooks",
+    "position": "wr"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "justin davis",
+    "first": "justin",
+    "last": "davis",
+    "position": "rb"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "gerald everett",
+    "first": "gerald",
+    "last": "everett",
+    "position": "te"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "jared goff",
+    "first": "jared",
+    "last": "goff",
+    "position": "qb"
+  },
+  {
+    "team": "los angeles rams",
+    "symbol": "LAR",
+    "fullname": "jalen greene",
+    "first": "jalen",
+    "last": "greene",
+    "position": "wr"
   },
   {
     "team": "los angeles rams",
@@ -4242,66 +1562,10 @@
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "malcolm brown",
-    "first": "malcolm",
-    "last": "brown",
-    "position": "rb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "john kelly",
-    "first": "john",
-    "last": "kelly",
-    "position": "rb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "justin davis",
-    "first": "justin",
-    "last": "davis",
-    "position": "rb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "fb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "brandin cooks",
-    "first": "brandin",
-    "last": "cooks",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "robert woods",
-    "first": "robert",
-    "last": "woods",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "cooper kupp",
-    "first": "cooper",
-    "last": "kupp",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "josh reynolds",
-    "first": "josh",
-    "last": "reynolds",
-    "position": "wr"
+    "fullname": "tyler higbee",
+    "first": "tyler",
+    "last": "higbee",
+    "position": "te"
   },
   {
     "team": "los angeles rams",
@@ -4314,33 +1578,17 @@
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "jojo natson",
-    "first": "jojo",
-    "last": "natson",
-    "position": "wr"
+    "fullname": "john kelly",
+    "first": "john",
+    "last": "kelly",
+    "position": "rb"
   },
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "mike thomas",
-    "first": "mike",
-    "last": "thomas",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "austin proehl",
-    "first": "austin",
-    "last": "proehl",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "nsimba webster",
-    "first": "nsimba",
-    "last": "webster",
+    "fullname": "cooper kupp",
+    "first": "cooper",
+    "last": "kupp",
     "position": "wr"
   },
   {
@@ -4354,22 +1602,6 @@
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "gerald everett",
-    "first": "gerald",
-    "last": "everett",
-    "position": "te"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "tyler higbee",
-    "first": "tyler",
-    "last": "higbee",
-    "position": "te"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
     "fullname": "johnny mundt",
     "first": "johnny",
     "last": "mundt",
@@ -4378,458 +1610,58 @@
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "kendall blanton",
-    "first": "kendall",
-    "last": "blanton",
-    "position": "te"
+    "fullname": "jojo natson",
+    "first": "jojo",
+    "last": "natson",
+    "position": "wr"
   },
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "keenen brown",
-    "first": "keenen",
-    "last": "brown",
-    "position": "te"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "romello brooker",
-    "first": "romello",
-    "last": "brooker",
-    "position": "te"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "andrew whitworth",
-    "first": "andrew",
-    "last": "whitworth",
-    "position": "lt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "bobby evans",
-    "first": "bobby",
-    "last": "evans",
-    "position": "lt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "matt kaskey",
-    "first": "matt",
-    "last": "kaskey",
-    "position": "lt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "joe noteboom",
-    "first": "joe",
-    "last": "noteboom",
-    "position": "lg"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "aaron neary",
-    "first": "aaron",
-    "last": "neary",
-    "position": "lg"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "brian allen",
-    "first": "brian",
-    "last": "allen",
-    "position": "c"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "jeremiah kolone",
-    "first": "jeremiah",
-    "last": "kolone",
-    "position": "c"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "aaron neary",
-    "first": "aaron",
-    "last": "neary",
-    "position": "c"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "austin blythe",
+    "fullname": "austin proehl",
     "first": "austin",
-    "last": "blythe",
-    "position": "rg"
+    "last": "proehl",
+    "position": "wr"
   },
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "jamil demby",
-    "first": "jamil",
-    "last": "demby",
-    "position": "rg"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "rob havenstein",
-    "first": "rob",
-    "last": "havenstein",
-    "position": "rt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "david edwards",
-    "first": "david",
-    "last": "edwards",
-    "position": "rt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "brandon hitner",
-    "first": "brandon",
-    "last": "hitner",
-    "position": "rt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "michael brockers",
-    "first": "michael",
-    "last": "brockers",
-    "position": "lde"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "john franklin-myers",
-    "first": "john",
-    "last": "franklin-myers",
-    "position": "lde"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "morgan fox",
-    "first": "morgan",
-    "last": "fox",
-    "position": "lde"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "tanzel smart",
-    "first": "tanzel",
-    "last": "smart",
-    "position": "ndt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "greg gaines",
-    "first": "greg",
-    "last": "gaines",
-    "position": "ndt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "marquise copeland",
-    "first": "marquise",
-    "last": "copeland",
-    "position": "ndt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "bryant jones",
-    "first": "bryant",
-    "last": "jones",
-    "position": "ndt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "aaron donald",
-    "first": "aaron",
-    "last": "donald",
-    "position": "rde"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "sebastian joseph-day",
-    "first": "sebastian",
-    "last": "joseph-day",
-    "position": "rde"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "boogie roberts",
-    "first": "boogie",
-    "last": "roberts",
-    "position": "rde"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "dante fowler",
-    "first": "dante",
-    "last": "fowler",
-    "position": "slb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "clay matthews",
-    "first": "clay",
-    "last": "matthews",
-    "position": "slb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "obo okoronkwo",
-    "first": "obo",
-    "last": "okoronkwo",
-    "position": "slb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "josh carraway",
+    "fullname": "josh reynolds",
     "first": "josh",
-    "last": "carraway",
-    "position": "slb"
+    "last": "reynolds",
+    "position": "wr"
   },
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "samson ebukam",
-    "first": "samson",
-    "last": "ebukam",
-    "position": "wlb"
+    "fullname": "mike thomas",
+    "first": "mike",
+    "last": "thomas",
+    "position": "wr"
   },
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "justin lawler",
-    "first": "justin",
-    "last": "lawler",
-    "position": "wlb"
+    "fullname": "nsimba webster",
+    "first": "nsimba",
+    "last": "webster",
+    "position": "wr"
   },
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "trevon young",
-    "first": "trevon",
-    "last": "young",
-    "position": "wlb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "landis durham",
-    "first": "landis",
-    "last": "durham",
-    "position": "wlb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "aqib talib",
-    "first": "aqib",
-    "last": "talib",
-    "position": "rcb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "troy hill",
-    "first": "troy",
-    "last": "hill",
-    "position": "rcb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "donte' deayon",
-    "first": "donte'",
-    "last": "deayon",
-    "position": "rcb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "kevin peterson",
-    "first": "kevin",
-    "last": "peterson",
-    "position": "rcb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "marcus peters",
-    "first": "marcus",
-    "last": "peters",
-    "position": "lcb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "nickell robey-coleman",
-    "first": "nickell",
-    "last": "robey-coleman",
-    "position": "lcb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "david long",
-    "first": "david",
-    "last": "long",
-    "position": "lcb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "darious williams",
-    "first": "darious",
-    "last": "williams",
-    "position": "lcb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "dominique hatfield",
-    "first": "dominique",
-    "last": "hatfield",
-    "position": "lcb"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "john johnson",
+    "fullname": "john wolford",
     "first": "john",
-    "last": "johnson",
-    "position": "ss"
+    "last": "wolford",
+    "position": "qb"
   },
   {
     "team": "los angeles rams",
     "symbol": "LAR",
-    "fullname": "ramon richards",
-    "first": "ramon",
-    "last": "richards",
-    "position": "ss"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "nick scott",
-    "first": "nick",
-    "last": "scott",
-    "position": "ss"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "jake gervase",
-    "first": "jake",
-    "last": "gervase",
-    "position": "ss"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "eric weddle",
-    "first": "eric",
-    "last": "weddle",
-    "position": "fs"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "taylor rapp",
-    "first": "taylor",
-    "last": "rapp",
-    "position": "fs"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "marqui christian",
-    "first": "marqui",
-    "last": "christian",
-    "position": "fs"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "steven parker",
-    "first": "steven",
-    "last": "parker",
-    "position": "fs"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "johnny hekker",
-    "first": "johnny",
-    "last": "hekker",
-    "position": "p"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "jake mcquaide",
-    "first": "jake",
-    "last": "mcquaide",
-    "position": "ls"
-  },
-  {
-    "team": "los angeles rams",
-    "symbol": "LAR",
-    "fullname": "johnny hekker",
-    "first": "johnny",
-    "last": "hekker",
-    "position": "h"
+    "fullname": "robert woods",
+    "first": "robert",
+    "last": "woods",
+    "position": "wr"
   },
   {
     "team": "los angeles rams",
@@ -4842,161 +1674,9 @@
   {
     "team": "washington redskins",
     "symbol": "WAS",
-    "fullname": "case keenum",
-    "first": "case",
-    "last": "keenum",
-    "position": "qb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "dwayne haskins",
-    "first": "dwayne",
-    "last": "haskins",
-    "position": "qb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "colt mccoy",
-    "first": "colt",
-    "last": "mccoy",
-    "position": "qb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "josh woodrum",
-    "first": "josh",
-    "last": "woodrum",
-    "position": "qb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "alex smith",
-    "first": "alex",
-    "last": "smith",
-    "position": "qb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "adrian peterson",
-    "first": "adrian",
-    "last": "peterson",
-    "position": "rb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "derrius guice",
-    "first": "derrius",
-    "last": "guice",
-    "position": "rb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "chris thompson",
-    "first": "chris",
-    "last": "thompson",
-    "position": "rb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "bryce love",
-    "first": "bryce",
-    "last": "love",
-    "position": "rb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "samaje perine",
-    "first": "samaje",
-    "last": "perine",
-    "position": "rb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "byron marshall",
-    "first": "byron",
-    "last": "marshall",
-    "position": "rb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "craig reynolds",
-    "first": "craig",
-    "last": "reynolds",
-    "position": "rb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "elijah wellman",
-    "first": "elijah",
-    "last": "wellman",
-    "position": "fb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "paul richardson",
-    "first": "paul",
-    "last": "richardson",
-    "position": "wr"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "josh doctson",
-    "first": "josh",
-    "last": "doctson",
-    "position": "wr"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "trey quinn",
-    "first": "trey",
-    "last": "quinn",
-    "position": "wr"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "terry mclaurin",
-    "first": "terry",
-    "last": "mclaurin",
-    "position": "wr"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "kelvin harmon",
-    "first": "kelvin",
-    "last": "harmon",
-    "position": "wr"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "cam sims",
-    "first": "cam",
-    "last": "sims",
-    "position": "wr"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "brian quick",
-    "first": "brian",
-    "last": "quick",
+    "fullname": "jehu chesson",
+    "first": "jehu",
+    "last": "chesson",
     "position": "wr"
   },
   {
@@ -5010,10 +1690,74 @@
   {
     "team": "washington redskins",
     "symbol": "WAS",
-    "fullname": "jehu chesson",
-    "first": "jehu",
-    "last": "chesson",
+    "fullname": "vernon davis",
+    "first": "vernon",
+    "last": "davis",
+    "position": "te"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "josh doctson",
+    "first": "josh",
+    "last": "doctson",
     "position": "wr"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "matt flanagan",
+    "first": "matt",
+    "last": "flanagan",
+    "position": "te"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "derrius guice",
+    "first": "derrius",
+    "last": "guice",
+    "position": "rb"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "kelvin harmon",
+    "first": "kelvin",
+    "last": "harmon",
+    "position": "wr"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "dwayne haskins",
+    "first": "dwayne",
+    "last": "haskins",
+    "position": "qb"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "jp holtz",
+    "first": "jp",
+    "last": "holtz",
+    "position": "te"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "dustin hopkins",
+    "first": "dustin",
+    "last": "hopkins",
+    "position": "k"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "case keenum",
+    "first": "case",
+    "last": "keenum",
+    "position": "qb"
   },
   {
     "team": "washington redskins",
@@ -5026,17 +1770,81 @@
   {
     "team": "washington redskins",
     "symbol": "WAS",
-    "fullname": "t.j. rahming",
-    "first": "t.j.",
-    "last": "rahming",
+    "fullname": "bryce love",
+    "first": "bryce",
+    "last": "love",
+    "position": "rb"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "byron marshall",
+    "first": "byron",
+    "last": "marshall",
+    "position": "rb"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "colt mccoy",
+    "first": "colt",
+    "last": "mccoy",
+    "position": "qb"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "terry mclaurin",
+    "first": "terry",
+    "last": "mclaurin",
     "position": "wr"
   },
   {
     "team": "washington redskins",
     "symbol": "WAS",
-    "fullname": "steven sims",
-    "first": "steven",
-    "last": "sims",
+    "fullname": "donald parham",
+    "first": "donald",
+    "last": "parham",
+    "position": "te"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "samaje perine",
+    "first": "samaje",
+    "last": "perine",
+    "position": "rb"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "adrian peterson",
+    "first": "adrian",
+    "last": "peterson",
+    "position": "rb"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "brian quick",
+    "first": "brian",
+    "last": "quick",
+    "position": "wr"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "trey quinn",
+    "first": "trey",
+    "last": "quinn",
+    "position": "wr"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "tj rahming",
+    "first": "tj",
+    "last": "rahming",
     "position": "wr"
   },
   {
@@ -5050,10 +1858,42 @@
   {
     "team": "washington redskins",
     "symbol": "WAS",
-    "fullname": "vernon davis",
-    "first": "vernon",
-    "last": "davis",
-    "position": "te"
+    "fullname": "craig reynolds",
+    "first": "craig",
+    "last": "reynolds",
+    "position": "rb"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "paul richardson",
+    "first": "paul",
+    "last": "richardson",
+    "position": "wr"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "cam sims",
+    "first": "cam",
+    "last": "sims",
+    "position": "wr"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "steven sims jr.",
+    "first": "steven",
+    "last": "sims jr.",
+    "position": "wr"
+  },
+  {
+    "team": "washington redskins",
+    "symbol": "WAS",
+    "fullname": "alex smith",
+    "first": "alex",
+    "last": "smith",
+    "position": "qb"
   },
   {
     "team": "washington redskins",
@@ -5066,481 +1906,25 @@
   {
     "team": "washington redskins",
     "symbol": "WAS",
-    "fullname": "matt flanagan",
-    "first": "matt",
-    "last": "flanagan",
-    "position": "te"
+    "fullname": "chris thompson",
+    "first": "chris",
+    "last": "thompson",
+    "position": "rb"
   },
   {
     "team": "washington redskins",
     "symbol": "WAS",
-    "fullname": "j.p. holtz",
-    "first": "j.p.",
-    "last": "holtz",
-    "position": "te"
+    "fullname": "shaun wilson",
+    "first": "shaun",
+    "last": "wilson",
+    "position": "rb"
   },
   {
     "team": "washington redskins",
     "symbol": "WAS",
-    "fullname": "donald parham",
-    "first": "donald",
-    "last": "parham",
-    "position": "te"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "trent williams",
-    "first": "trent",
-    "last": "williams",
-    "position": "lt"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "geron christian",
-    "first": "geron",
-    "last": "christian",
-    "position": "lt"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "timon parris",
-    "first": "timon",
-    "last": "parris",
-    "position": "lt"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "ereck flowers",
-    "first": "ereck",
-    "last": "flowers",
-    "position": "lg"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "chase roullier",
-    "first": "chase",
-    "last": "roullier",
-    "position": "c"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "ross pierschbacher",
-    "first": "ross",
-    "last": "pierschbacher",
-    "position": "c"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "casey dunn",
-    "first": "casey",
-    "last": "dunn",
-    "position": "c"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "brandon scherff",
-    "first": "brandon",
-    "last": "scherff",
-    "position": "rg"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "tyler catalina",
-    "first": "tyler",
-    "last": "catalina",
-    "position": "rg"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "zac kerin",
-    "first": "zac",
-    "last": "kerin",
-    "position": "rg"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "morgan moses",
-    "first": "morgan",
-    "last": "moses",
-    "position": "rt"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "brian wallace",
-    "first": "brian",
-    "last": "wallace",
-    "position": "rt"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "jonathan allen",
-    "first": "jonathan",
-    "last": "allen",
-    "position": "lde"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "jojo wicker",
-    "first": "jojo",
-    "last": "wicker",
-    "position": "lde"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "ryan bee",
-    "first": "ryan",
-    "last": "bee",
-    "position": "lde"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "daron payne",
-    "first": "daron",
-    "last": "payne",
-    "position": "ndt"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "tim settle",
-    "first": "tim",
-    "last": "settle",
-    "position": "ndt"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "austin maloata",
-    "first": "austin",
-    "last": "maloata",
-    "position": "ndt"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "matthew ioannidis",
-    "first": "matthew",
-    "last": "ioannidis",
-    "position": "rde"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "caleb brantley",
-    "first": "caleb",
-    "last": "brantley",
-    "position": "rde"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "jonathan bonner",
-    "first": "jonathan",
-    "last": "bonner",
-    "position": "rde"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "ryan kerrigan",
-    "first": "ryan",
-    "last": "kerrigan",
-    "position": "slb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "cassanova mckinzy",
-    "first": "cassanova",
-    "last": "mckinzy",
-    "position": "slb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "marcus smith",
-    "first": "marcus",
-    "last": "smith",
-    "position": "slb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "montez sweat",
-    "first": "montez",
-    "last": "sweat",
-    "position": "wlb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "ryan anderson",
-    "first": "ryan",
-    "last": "anderson",
-    "position": "wlb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "andrew ankrah",
-    "first": "andrew",
-    "last": "ankrah",
-    "position": "wlb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "jordan brailford",
-    "first": "jordan",
-    "last": "brailford",
-    "position": "wlb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "quinton dunbar",
-    "first": "quinton",
-    "last": "dunbar",
-    "position": "rcb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "greg stroman",
-    "first": "greg",
-    "last": "stroman",
-    "position": "rcb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "dominique rodgers-cromartie",
-    "first": "dominique",
-    "last": "rodgers-cromartie",
-    "position": "rcb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "danny johnson",
-    "first": "danny",
-    "last": "johnson",
-    "position": "rcb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "deion harris",
-    "first": "deion",
-    "last": "harris",
-    "position": "rcb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "josh norman",
+    "fullname": "josh woodrum",
     "first": "josh",
-    "last": "norman",
-    "position": "lcb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "fabian moreau",
-    "first": "fabian",
-    "last": "moreau",
-    "position": "lcb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "adonis alexander",
-    "first": "adonis",
-    "last": "alexander",
-    "position": "lcb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "jimmy moreland",
-    "first": "jimmy",
-    "last": "moreland",
-    "position": "lcb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "ashton lampkin",
-    "first": "ashton",
-    "last": "lampkin",
-    "position": "lcb"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "landon collins",
-    "first": "landon",
-    "last": "collins",
-    "position": "ss"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "jeremy reaves",
-    "first": "jeremy",
-    "last": "reaves",
-    "position": "ss"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "jojo mcintosh",
-    "first": "jojo",
-    "last": "mcintosh",
-    "position": "ss"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "montae nicholson",
-    "first": "montae",
-    "last": "nicholson",
-    "position": "fs"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "troy apke",
-    "first": "troy",
-    "last": "apke",
-    "position": "fs"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "deshazor everett",
-    "first": "deshazor",
-    "last": "everett",
-    "position": "fs"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "tress way",
-    "first": "tress",
-    "last": "way",
-    "position": "p"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "nick sundberg",
-    "first": "nick",
-    "last": "sundberg",
-    "position": "ls"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "andrew east",
-    "first": "andrew",
-    "last": "east",
-    "position": "ls"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "tress way",
-    "first": "tress",
-    "last": "way",
-    "position": "h"
-  },
-  {
-    "team": "washington redskins",
-    "symbol": "WAS",
-    "fullname": "dustin hopkins",
-    "first": "dustin",
-    "last": "hopkins",
-    "position": "k"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "eli manning",
-    "first": "eli",
-    "last": "manning",
-    "position": "qb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "daniel jones",
-    "first": "daniel",
-    "last": "jones",
-    "position": "qb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "alex tanney",
-    "first": "alex",
-    "last": "tanney",
-    "position": "qb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "kyle lauletta",
-    "first": "kyle",
-    "last": "lauletta",
-    "position": "qb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "eric dungey",
-    "first": "eric",
-    "last": "dungey",
+    "last": "woodrum",
     "position": "qb"
   },
   {
@@ -5554,145 +1938,9 @@
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "paul perkins",
-    "first": "paul",
-    "last": "perkins",
-    "position": "rb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "wayne gallman",
-    "first": "wayne",
-    "last": "gallman",
-    "position": "rb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "rod smith",
-    "first": "rod",
-    "last": "smith",
-    "position": "rb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "jon hilliman",
-    "first": "jon",
-    "last": "hilliman",
-    "position": "rb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "elijhaa penny",
-    "first": "elijhaa",
-    "last": "penny",
-    "position": "fb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "sterling shepard",
-    "first": "sterling",
-    "last": "shepard",
-    "position": "wr"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "golden tate",
-    "first": "golden",
-    "last": "tate",
-    "position": "wr"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "corey coleman",
-    "first": "corey",
-    "last": "coleman",
-    "position": "wr"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "cody latimer",
-    "first": "cody",
-    "last": "latimer",
-    "position": "wr"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "darius slayton",
-    "first": "darius",
-    "last": "slayton",
-    "position": "wr"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "bennie fowler",
-    "first": "bennie",
-    "last": "fowler",
-    "position": "wr"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "russell shepard",
-    "first": "russell",
-    "last": "shepard",
-    "position": "wr"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "alonzo russell",
-    "first": "alonzo",
-    "last": "russell",
-    "position": "wr"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "brittan golden",
-    "first": "brittan",
-    "last": "golden",
-    "position": "wr"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "alex wesley",
-    "first": "alex",
-    "last": "wesley",
-    "position": "wr"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "evan engram",
-    "first": "evan",
-    "last": "engram",
-    "position": "te"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "rhett ellison",
-    "first": "rhett",
-    "last": "ellison",
-    "position": "te"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "scott simonson",
-    "first": "scott",
-    "last": "simonson",
+    "fullname": "cj conrad",
+    "first": "cj",
+    "last": "conrad",
     "position": "te"
   },
   {
@@ -5706,466 +1954,114 @@
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "c.j. conrad",
-    "first": "c.j.",
-    "last": "conrad",
+    "fullname": "rhett ellison",
+    "first": "rhett",
+    "last": "ellison",
     "position": "te"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "nate solder",
-    "first": "nate",
-    "last": "solder",
-    "position": "lt"
+    "fullname": "evan engram",
+    "first": "evan",
+    "last": "engram",
+    "position": "te"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "brian mihalik",
-    "first": "brian",
-    "last": "mihalik",
-    "position": "lt"
+    "fullname": "amba etta-tawo",
+    "first": "amba",
+    "last": "etta-tawo",
+    "position": "wr"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "paul adams",
-    "first": "paul",
-    "last": "adams",
-    "position": "lt"
+    "fullname": "bennie fowler",
+    "first": "bennie",
+    "last": "fowler",
+    "position": "wr"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "will hernandez",
-    "first": "will",
-    "last": "hernandez",
-    "position": "lg"
+    "fullname": "wayne gallman",
+    "first": "wayne",
+    "last": "gallman",
+    "position": "rb"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "nick gates",
-    "first": "nick",
-    "last": "gates",
-    "position": "lg"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "austin droogsma",
-    "first": "austin",
-    "last": "droogsma",
-    "position": "lg"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "jon halapio",
-    "first": "jon",
-    "last": "halapio",
-    "position": "c"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "spencer pulley",
-    "first": "spencer",
-    "last": "pulley",
-    "position": "c"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "james o'hagan",
-    "first": "james",
-    "last": "o'hagan",
-    "position": "c"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "kevin zeitler",
-    "first": "kevin",
-    "last": "zeitler",
-    "position": "rg"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "chad slade",
-    "first": "chad",
-    "last": "slade",
-    "position": "rg"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "mike remmers",
-    "first": "mike",
-    "last": "remmers",
-    "position": "rt"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "chad wheeler",
-    "first": "chad",
-    "last": "wheeler",
-    "position": "rt"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "dalvin tomlinson",
-    "first": "dalvin",
-    "last": "tomlinson",
-    "position": "lde"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "r.j. mcintosh",
-    "first": "r.j.",
-    "last": "mcintosh",
-    "position": "lde"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "olsen pierre",
-    "first": "olsen",
-    "last": "pierre",
-    "position": "lde"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "freedom akinmoladun",
-    "first": "freedom",
-    "last": "akinmoladun",
-    "position": "lde"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "nate harvey",
-    "first": "nate",
-    "last": "harvey",
-    "position": "lde"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "dexter lawrence",
-    "first": "dexter",
-    "last": "lawrence",
-    "position": "ndt"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "john jenkins",
-    "first": "john",
-    "last": "jenkins",
-    "position": "ndt"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "b.j. hill",
-    "first": "b.j.",
-    "last": "hill",
-    "position": "rde"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "jake ceresna",
-    "first": "jake",
-    "last": "ceresna",
-    "position": "rde"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "chris slayton",
-    "first": "chris",
-    "last": "slayton",
-    "position": "rde"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "alex jenkins",
-    "first": "alex",
-    "last": "jenkins",
-    "position": "rde"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "markus golden",
-    "first": "markus",
+    "fullname": "brittan golden",
+    "first": "brittan",
     "last": "golden",
-    "position": "slb"
+    "position": "wr"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "oshane ximines",
-    "first": "oshane",
-    "last": "ximines",
-    "position": "slb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "jonathan anderson",
+    "fullname": "jonathan hilliman",
     "first": "jonathan",
-    "last": "anderson",
-    "position": "slb"
+    "last": "hilliman",
+    "position": "rb"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "lorenzo carter",
-    "first": "lorenzo",
-    "last": "carter",
-    "position": "wlb"
+    "fullname": "daniel jones",
+    "first": "daniel",
+    "last": "jones",
+    "position": "qb"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "kareem martin",
-    "first": "kareem",
-    "last": "martin",
-    "position": "wlb"
+    "fullname": "tj jones",
+    "first": "tj",
+    "last": "jones",
+    "position": "wr"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "avery moss",
-    "first": "avery",
-    "last": "moss",
-    "position": "wlb"
+    "fullname": "cody latimer",
+    "first": "cody",
+    "last": "latimer",
+    "position": "wr"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "janoris jenkins",
-    "first": "janoris",
-    "last": "jenkins",
-    "position": "rcb"
+    "fullname": "kyle lauletta",
+    "first": "kyle",
+    "last": "lauletta",
+    "position": "qb"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "julian love",
-    "first": "julian",
-    "last": "love",
-    "position": "rcb"
+    "fullname": "eli manning",
+    "first": "eli",
+    "last": "manning",
+    "position": "qb"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "corey ballentine",
-    "first": "corey",
-    "last": "ballentine",
-    "position": "rcb"
+    "fullname": "elijhaa penny",
+    "first": "elijhaa",
+    "last": "penny",
+    "position": "rb"
   },
   {
     "team": "new york giants",
     "symbol": "NYG",
-    "fullname": "antonio hamilton",
-    "first": "antonio",
-    "last": "hamilton",
-    "position": "rcb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "ronald zamort",
-    "first": "ronald",
-    "last": "zamort",
-    "position": "rcb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "jake carlock",
-    "first": "jake",
-    "last": "carlock",
-    "position": "rcb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "sam beal",
-    "first": "sam",
-    "last": "beal",
-    "position": "lcb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "deandre baker",
-    "first": "deandre",
-    "last": "baker",
-    "position": "lcb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "grant haley",
-    "first": "grant",
-    "last": "haley",
-    "position": "lcb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "tony lippett",
-    "first": "tony",
-    "last": "lippett",
-    "position": "lcb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "henre' toliver",
-    "first": "henre'",
-    "last": "toliver",
-    "position": "lcb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "tenny adewusi",
-    "first": "tenny",
-    "last": "adewusi",
-    "position": "lcb"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "jabrill peppers",
-    "first": "jabrill",
-    "last": "peppers",
-    "position": "ss"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "michael thomas",
-    "first": "michael",
-    "last": "thomas",
-    "position": "ss"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "kenny ladler",
-    "first": "kenny",
-    "last": "ladler",
-    "position": "ss"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "mark mclaurin",
-    "first": "mark",
-    "last": "mclaurin",
-    "position": "ss"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "antoine bethea",
-    "first": "antoine",
-    "last": "bethea",
-    "position": "fs"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "sean chandler",
-    "first": "sean",
-    "last": "chandler",
-    "position": "fs"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "kam moore",
-    "first": "kam",
-    "last": "moore",
-    "position": "fs"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "riley dixon",
-    "first": "riley",
-    "last": "dixon",
-    "position": "p"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "ryan anderson",
-    "first": "ryan",
-    "last": "anderson",
-    "position": "p"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "zak deossie",
-    "first": "zak",
-    "last": "deossie",
-    "position": "ls"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "taybor pepper",
-    "first": "taybor",
-    "last": "pepper",
-    "position": "ls"
-  },
-  {
-    "team": "new york giants",
-    "symbol": "NYG",
-    "fullname": "riley dixon",
-    "first": "riley",
-    "last": "dixon",
-    "position": "h"
+    "fullname": "paul perkins",
+    "first": "paul",
+    "last": "perkins",
+    "position": "rb"
   },
   {
     "team": "new york giants",
@@ -6176,32 +2072,112 @@
     "position": "k"
   },
   {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "kyler murray",
-    "first": "kyler",
-    "last": "murray",
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "alonzo russell",
+    "first": "alonzo",
+    "last": "russell",
+    "position": "wr"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "da'mari scott",
+    "first": "da'mari",
+    "last": "scott",
+    "position": "wr"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "isaiah searight",
+    "first": "isaiah",
+    "last": "searight",
+    "position": "te"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "russell shepard",
+    "first": "russell",
+    "last": "shepard",
+    "position": "wr"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "sterling shepard",
+    "first": "sterling",
+    "last": "shepard",
+    "position": "wr"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "scott simonson",
+    "first": "scott",
+    "last": "simonson",
+    "position": "te"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "darius slayton",
+    "first": "darius",
+    "last": "slayton",
+    "position": "wr"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "rod smith",
+    "first": "rod",
+    "last": "smith",
+    "position": "rb"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "alex tanney",
+    "first": "alex",
+    "last": "tanney",
     "position": "qb"
   },
   {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "brett hundley",
-    "first": "brett",
-    "last": "hundley",
-    "position": "qb"
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "golden tate",
+    "first": "golden",
+    "last": "tate",
+    "position": "wr"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "alex wesley",
+    "first": "alex",
+    "last": "wesley",
+    "position": "wr"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "reggie white jr.",
+    "first": "reggie",
+    "last": "white jr.",
+    "position": "wr"
+  },
+  {
+    "team": "new york giants",
+    "symbol": "NYG",
+    "fullname": "corey coleman",
+    "first": "corey",
+    "last": "coleman",
+    "position": "wr"
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "chad kanoff",
-    "first": "chad",
-    "last": "kanoff",
-    "position": "qb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
+    "symbol": "ARZ",
     "fullname": "drew anderson",
     "first": "drew",
     "last": "anderson",
@@ -6209,199 +2185,7 @@
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "david johnson",
-    "first": "david",
-    "last": "johnson",
-    "position": "rb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "chase edmonds",
-    "first": "chase",
-    "last": "edmonds",
-    "position": "rb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "t.j. logan",
-    "first": "t.j.",
-    "last": "logan",
-    "position": "rb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "d.j. foster",
-    "first": "d.j.",
-    "last": "foster",
-    "position": "rb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "xavier turner",
-    "first": "xavier",
-    "last": "turner",
-    "position": "rb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "wes hills",
-    "first": "wes",
-    "last": "hills",
-    "position": "rb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "dontae strickland",
-    "first": "dontae",
-    "last": "strickland",
-    "position": "rb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "fb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "larry fitzgerald",
-    "first": "larry",
-    "last": "fitzgerald",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "christian kirk",
-    "first": "christian",
-    "last": "kirk",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "andy isabella",
-    "first": "andy",
-    "last": "isabella",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "hakeem butler",
-    "first": "hakeem",
-    "last": "butler",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "trent sherfield",
-    "first": "trent",
-    "last": "sherfield",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "keesean johnson",
-    "first": "keesean",
-    "last": "johnson",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "kevin white",
-    "first": "kevin",
-    "last": "white",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "chad williams",
-    "first": "chad",
-    "last": "williams",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "damiere byrd",
-    "first": "damiere",
-    "last": "byrd",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "pharoh cooper",
-    "first": "pharoh",
-    "last": "cooper",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "a.j. richardson",
-    "first": "a.j.",
-    "last": "richardson",
-    "position": "wr"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "charles clay",
-    "first": "charles",
-    "last": "clay",
-    "position": "te"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "ricky seals-jones",
-    "first": "ricky",
-    "last": "seals-jones",
-    "position": "te"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "maxx williams",
-    "first": "maxx",
-    "last": "williams",
-    "position": "te"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "caleb wilson",
-    "first": "caleb",
-    "last": "wilson",
-    "position": "te"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "darrell daniels",
-    "first": "darrell",
-    "last": "daniels",
-    "position": "te"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
+    "symbol": "ARZ",
     "fullname": "drew belcher",
     "first": "drew",
     "last": "belcher",
@@ -6409,475 +2193,227 @@
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "d.j. humphries",
-    "first": "d.j.",
-    "last": "humphries",
-    "position": "lt"
+    "symbol": "ARZ",
+    "fullname": "hakeem butler",
+    "first": "hakeem",
+    "last": "butler",
+    "position": "wr"
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "korey cunningham",
-    "first": "korey",
-    "last": "cunningham",
-    "position": "lt"
+    "symbol": "ARZ",
+    "fullname": "damiere byrd",
+    "first": "damiere",
+    "last": "byrd",
+    "position": "wr"
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "josh miles",
-    "first": "josh",
-    "last": "miles",
-    "position": "lt"
+    "symbol": "ARZ",
+    "fullname": "charles clay",
+    "first": "charles",
+    "last": "clay",
+    "position": "te"
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "desmond harrison",
-    "first": "desmond",
-    "last": "harrison",
-    "position": "lt"
+    "symbol": "ARZ",
+    "fullname": "pharoh cooper",
+    "first": "pharoh",
+    "last": "cooper",
+    "position": "wr"
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "j.r. sweezy",
-    "first": "j.r.",
-    "last": "sweezy",
-    "position": "lg"
+    "symbol": "ARZ",
+    "fullname": "darrell daniels",
+    "first": "darrell",
+    "last": "daniels",
+    "position": "te"
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "max garcia",
-    "first": "max",
-    "last": "garcia",
-    "position": "lg"
+    "symbol": "ARZ",
+    "fullname": "chase edmonds",
+    "first": "chase",
+    "last": "edmonds",
+    "position": "rb"
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "jeremy vujnovich",
-    "first": "jeremy",
-    "last": "vujnovich",
-    "position": "lg"
+    "symbol": "ARZ",
+    "fullname": "larry fitzgerald",
+    "first": "larry",
+    "last": "fitzgerald",
+    "position": "wr"
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "mason cole",
-    "first": "mason",
-    "last": "cole",
-    "position": "c"
+    "symbol": "ARZ",
+    "fullname": "dj foster",
+    "first": "dj",
+    "last": "foster",
+    "position": "wr"
   },
   {
     "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "a.q. shipley",
-    "first": "a.q.",
-    "last": "shipley",
-    "position": "c"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "lamont gaillard",
-    "first": "lamont",
-    "last": "gaillard",
-    "position": "c"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "coleman shelton",
-    "first": "coleman",
-    "last": "shelton",
-    "position": "c"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "justin pugh",
-    "first": "justin",
-    "last": "pugh",
-    "position": "rg"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "colby gossett",
-    "first": "colby",
-    "last": "gossett",
-    "position": "rg"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "rees odhiambo",
-    "first": "rees",
-    "last": "odhiambo",
-    "position": "rg"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "marcus gilbert",
-    "first": "marcus",
-    "last": "gilbert",
-    "position": "rt"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "will holden",
-    "first": "will",
-    "last": "holden",
-    "position": "rt"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "william sweet",
-    "first": "william",
-    "last": "sweet",
-    "position": "rt"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "rodney gunter",
-    "first": "rodney",
-    "last": "gunter",
-    "position": "lde"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "zach allen",
-    "first": "zach",
-    "last": "allen",
-    "position": "lde"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "cameron malveaux",
-    "first": "cameron",
-    "last": "malveaux",
-    "position": "lde"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "corey peters",
-    "first": "corey",
-    "last": "peters",
-    "position": "ndt"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "terrell mcclain",
-    "first": "terrell",
-    "last": "mcclain",
-    "position": "ndt"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "vincent valentine",
-    "first": "vincent",
-    "last": "valentine",
-    "position": "ndt"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "immanuel turner",
-    "first": "immanuel",
-    "last": "turner",
-    "position": "ndt"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "darius philon",
-    "first": "darius",
-    "last": "philon",
-    "position": "rde"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "robert nkemdiche",
-    "first": "robert",
-    "last": "nkemdiche",
-    "position": "rde"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "michael dogbe",
-    "first": "michael",
-    "last": "dogbe",
-    "position": "rde"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "miles brown",
-    "first": "miles",
-    "last": "brown",
-    "position": "rde"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "chandler jones",
-    "first": "chandler",
-    "last": "jones",
-    "position": "slb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "vontarrius dora",
-    "first": "vontarrius",
-    "last": "dora",
-    "position": "slb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "dante booker",
-    "first": "dante",
-    "last": "booker",
-    "position": "slb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "terrell suggs",
-    "first": "terrell",
-    "last": "suggs",
-    "position": "wlb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "brooks reed",
-    "first": "brooks",
-    "last": "reed",
-    "position": "wlb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "pete robertson",
-    "first": "pete",
-    "last": "robertson",
-    "position": "wlb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "robert alford",
-    "first": "robert",
-    "last": "alford",
-    "position": "rcb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "chris jones",
-    "first": "chris",
-    "last": "jones",
-    "position": "rcb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "deatrick nichols",
-    "first": "deatrick",
-    "last": "nichols",
-    "position": "rcb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "patrick peterson",
-    "first": "patrick",
-    "last": "peterson",
-    "position": "lcb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "byron murphy",
-    "first": "byron",
-    "last": "murphy",
-    "position": "lcb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "tramaine brock",
-    "first": "tramaine",
-    "last": "brock",
-    "position": "lcb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "brandon williams",
-    "first": "brandon",
-    "last": "williams",
-    "position": "lcb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "chris jones",
-    "first": "chris",
-    "last": "jones",
-    "position": "lcb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "nate brooks",
-    "first": "nate",
-    "last": "brooks",
-    "position": "lcb"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "d.j. swearinger",
-    "first": "d.j.",
-    "last": "swearinger",
-    "position": "ss"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "rudy ford",
-    "first": "rudy",
-    "last": "ford",
-    "position": "ss"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "jonathan owens",
-    "first": "jonathan",
-    "last": "owens",
-    "position": "ss"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "tyler sigler",
-    "first": "tyler",
-    "last": "sigler",
-    "position": "ss"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "budda baker",
-    "first": "budda",
-    "last": "baker",
-    "position": "fs"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "deionte thompson",
-    "first": "deionte",
-    "last": "thompson",
-    "position": "fs"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "josh shaw",
-    "first": "josh",
-    "last": "shaw",
-    "position": "fs"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "andy lee",
-    "first": "andy",
-    "last": "lee",
-    "position": "p"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "ryan winslow",
-    "first": "ryan",
-    "last": "winslow",
-    "position": "p"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "aaron brewer",
-    "first": "aaron",
-    "last": "brewer",
-    "position": "ls"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
-    "fullname": "andy lee",
-    "first": "andy",
-    "last": "lee",
-    "position": "h"
-  },
-  {
-    "team": "arizona cardinals",
-    "symbol": "ARI",
+    "symbol": "ARZ",
     "fullname": "zane gonzalez",
     "first": "zane",
     "last": "gonzalez",
     "position": "k"
   },
   {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "wes hills",
+    "first": "wes",
+    "last": "hills",
+    "position": "rb"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "brett hundley",
+    "first": "brett",
+    "last": "hundley",
+    "position": "qb"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "andy isabella",
+    "first": "andy",
+    "last": "isabella",
+    "position": "wr"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "david johnson",
+    "first": "david",
+    "last": "johnson",
+    "position": "rb"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "keesean johnson",
+    "first": "keesean",
+    "last": "johnson",
+    "position": "wr"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "chad kanoff",
+    "first": "chad",
+    "last": "kanoff",
+    "position": "qb"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "christian kirk",
+    "first": "christian",
+    "last": "kirk",
+    "position": "wr"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "tj logan",
+    "first": "tj",
+    "last": "logan",
+    "position": "rb"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "kyler murray",
+    "first": "kyler",
+    "last": "murray",
+    "position": "qb"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "aj richardson",
+    "first": "aj",
+    "last": "richardson",
+    "position": "wr"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "ricky seals-jones",
+    "first": "ricky",
+    "last": "seals-jones",
+    "position": "te"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "trent sherfield",
+    "first": "trent",
+    "last": "sherfield",
+    "position": "wr"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "dontae strickland",
+    "first": "dontae",
+    "last": "strickland",
+    "position": "rb"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "kevin white",
+    "first": "kevin",
+    "last": "white",
+    "position": "wr"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "chad williams",
+    "first": "chad",
+    "last": "williams",
+    "position": "wr"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "maxx williams",
+    "first": "maxx",
+    "last": "williams",
+    "position": "te"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "caleb wilson",
+    "first": "caleb",
+    "last": "wilson",
+    "position": "te"
+  },
+  {
+    "team": "arizona cardinals",
+    "symbol": "ARZ",
+    "fullname": "isaac zico",
+    "first": "isaac",
+    "last": "zico",
+    "position": "wr"
+  },
+  {
     "team": "indianapolis colts",
     "symbol": "IND",
-    "fullname": "andrew luck",
-    "first": "andrew",
-    "last": "luck",
-    "position": "qb"
+    "fullname": "mo alie-cox",
+    "first": "mo",
+    "last": "alie-cox",
+    "position": "te"
   },
   {
     "team": "indianapolis colts",
@@ -6890,10 +2426,138 @@
   {
     "team": "indianapolis colts",
     "symbol": "IND",
-    "fullname": "phillip walker",
-    "first": "phillip",
-    "last": "walker",
-    "position": "qb"
+    "fullname": "deon cain",
+    "first": "deon",
+    "last": "cain",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "parris campbell",
+    "first": "parris",
+    "last": "campbell",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "zach conque",
+    "first": "zach",
+    "last": "conque",
+    "position": "te"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "jack doyle",
+    "first": "jack",
+    "last": "doyle",
+    "position": "te"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "ashton dulin",
+    "first": "ashton",
+    "last": "dulin",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "eric ebron",
+    "first": "eric",
+    "last": "ebron",
+    "position": "te"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "d'onta foreman",
+    "first": "d'onta",
+    "last": "foreman",
+    "position": "rb"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "daurice fountain",
+    "first": "daurice",
+    "last": "fountain",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "devin funchess",
+    "first": "devin",
+    "last": "funchess",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "penny hart",
+    "first": "penny",
+    "last": "hart",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "cole hedlund",
+    "first": "cole",
+    "last": "hedlund",
+    "position": "k"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "hale hentges",
+    "first": "hale",
+    "last": "hentges",
+    "position": "te"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "ty hilton",
+    "first": "ty",
+    "last": "hilton",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "nyheim hines",
+    "first": "nyheim",
+    "last": "hines",
+    "position": "rb"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "krishawn hogan",
+    "first": "krishawn",
+    "last": "hogan",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "gabe holmes",
+    "first": "gabe",
+    "last": "holmes",
+    "position": "te"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "marcus johnson",
+    "first": "marcus",
+    "last": "johnson",
+    "position": "wr"
   },
   {
     "team": "indianapolis colts",
@@ -6901,6 +2565,22 @@
     "fullname": "chad kelly",
     "first": "chad",
     "last": "kelly",
+    "position": "qb"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "roger lewis",
+    "first": "roger",
+    "last": "lewis",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "andrew luck",
+    "first": "andrew",
+    "last": "luck",
     "position": "qb"
   },
   {
@@ -6914,16 +2594,64 @@
   {
     "team": "indianapolis colts",
     "symbol": "IND",
-    "fullname": "nyheim hines",
-    "first": "nyheim",
-    "last": "hines",
-    "position": "rb"
+    "fullname": "george odum",
+    "first": "george",
+    "last": "odum",
+    "position": "wr"
   },
   {
     "team": "indianapolis colts",
     "symbol": "IND",
-    "fullname": "spencer ware",
-    "first": "spencer",
+    "fullname": "zach pascal",
+    "first": "zach",
+    "last": "pascal",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "chester rogers",
+    "first": "chester",
+    "last": "rogers",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "ross travis",
+    "first": "ross",
+    "last": "travis",
+    "position": "te"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "jordan veasy",
+    "first": "jordan",
+    "last": "veasy",
+    "position": "wr"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "adam vinatieri",
+    "first": "adam",
+    "last": "vinatieri",
+    "position": "k"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "phillip walker",
+    "first": "phillip",
+    "last": "walker",
+    "position": "qb"
+  },
+  {
+    "team": "indianapolis colts",
+    "symbol": "IND",
+    "fullname": "aca'cedric ware",
+    "first": "aca'cedric",
     "last": "ware",
     "position": "rb"
   },
@@ -6946,82 +2674,10 @@
   {
     "team": "indianapolis colts",
     "symbol": "IND",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "fb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "t.y. hilton",
-    "first": "t.y.",
-    "last": "hilton",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "devin funchess",
-    "first": "devin",
-    "last": "funchess",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "chester rogers",
-    "first": "chester",
-    "last": "rogers",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "parris campbell",
-    "first": "parris",
-    "last": "campbell",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "zach pascal",
-    "first": "zach",
-    "last": "pascal",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "deon cain",
-    "first": "deon",
-    "last": "cain",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "reece fountain",
-    "first": "reece",
-    "last": "fountain",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "marcus johnson",
-    "first": "marcus",
-    "last": "johnson",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "krishawn hogan",
-    "first": "krishawn",
-    "last": "hogan",
-    "position": "wr"
+    "fullname": "billy brown",
+    "first": "billy",
+    "last": "brown",
+    "position": "te"
   },
   {
     "team": "indianapolis colts",
@@ -7034,658 +2690,10 @@
   {
     "team": "indianapolis colts",
     "symbol": "IND",
-    "fullname": "jordan veasy",
-    "first": "jordan",
-    "last": "veasy",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "penny hart",
-    "first": "penny",
-    "last": "hart",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "ashton dulin",
-    "first": "ashton",
-    "last": "dulin",
-    "position": "wr"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "eric ebron",
-    "first": "eric",
-    "last": "ebron",
-    "position": "te"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "jack doyle",
-    "first": "jack",
-    "last": "doyle",
-    "position": "te"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "mo alie-cox",
-    "first": "mo",
-    "last": "alie-cox",
-    "position": "te"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "billy brown",
-    "first": "billy",
-    "last": "brown",
-    "position": "te"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "ross travis",
-    "first": "ross",
-    "last": "travis",
-    "position": "te"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "gabe holmes",
-    "first": "gabe",
-    "last": "holmes",
-    "position": "te"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "hale hentges",
-    "first": "hale",
-    "last": "hentges",
-    "position": "te"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "anthony castonzo",
-    "first": "anthony",
-    "last": "castonzo",
-    "position": "lt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "le'raven clark",
-    "first": "le'raven",
-    "last": "clark",
-    "position": "lt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "jackson barton",
-    "first": "jackson",
-    "last": "barton",
-    "position": "lt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "antonio garcia",
-    "first": "antonio",
-    "last": "garcia",
-    "position": "lt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "quenton nelson",
-    "first": "quenton",
-    "last": "nelson",
-    "position": "lg"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "ryan kelly",
-    "first": "ryan",
-    "last": "kelly",
-    "position": "c"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "evan boehm",
-    "first": "evan",
-    "last": "boehm",
-    "position": "c"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "jake eldrenkamp",
-    "first": "jake",
-    "last": "eldrenkamp",
-    "position": "c"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "mark glowinski",
-    "first": "mark",
-    "last": "glowinski",
-    "position": "rg"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "nico siragusa",
-    "first": "nico",
-    "last": "siragusa",
-    "position": "rg"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "braden smith",
-    "first": "braden",
-    "last": "smith",
-    "position": "rt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "joe haeg",
-    "first": "joe",
-    "last": "haeg",
-    "position": "rt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "j'marcus webb",
-    "first": "j'marcus",
-    "last": "webb",
-    "position": "rt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "william poehls",
-    "first": "william",
-    "last": "poehls",
-    "position": "rt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "margus hunt",
-    "first": "margus",
-    "last": "hunt",
-    "position": "ldt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "grover stewart",
-    "first": "grover",
-    "last": "stewart",
-    "position": "ldt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "jabaal sheard",
-    "first": "jabaal",
-    "last": "sheard",
-    "position": "lde"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "ben banogu",
-    "first": "ben",
-    "last": "banogu",
-    "position": "lde"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "al-quadin muhammad",
-    "first": "al-quadin",
-    "last": "muhammad",
-    "position": "lde"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "denico autry",
-    "first": "denico",
-    "last": "autry",
-    "position": "rdt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "jihad ward",
-    "first": "jihad",
-    "last": "ward",
-    "position": "rdt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "sterling shippy",
-    "first": "sterling",
-    "last": "shippy",
-    "position": "rdt"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "justin houston",
-    "first": "justin",
-    "last": "houston",
-    "position": "rde"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "kemoko turay",
-    "first": "kemoko",
-    "last": "turay",
-    "position": "rde"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "tyquan lewis",
-    "first": "tyquan",
-    "last": "lewis",
-    "position": "rde"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "anthony walker",
-    "first": "anthony",
-    "last": "walker",
-    "position": "mlb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "bobby okereke",
-    "first": "bobby",
-    "last": "okereke",
-    "position": "mlb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "ahmad thomas",
-    "first": "ahmad",
-    "last": "thomas",
-    "position": "mlb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "zaire franklin",
-    "first": "zaire",
-    "last": "franklin",
-    "position": "slb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "skai moore",
-    "first": "skai",
-    "last": "moore",
-    "position": "slb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "carroll phillips",
-    "first": "carroll",
-    "last": "phillips",
-    "position": "slb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "e.j. speed",
-    "first": "e.j.",
-    "last": "speed",
-    "position": "slb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "tre thomas",
-    "first": "tre",
-    "last": "thomas",
-    "position": "slb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "darius leonard",
-    "first": "darius",
-    "last": "leonard",
-    "position": "wlb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "gerri green",
-    "first": "gerri",
-    "last": "green",
-    "position": "wlb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "matthew adams",
-    "first": "matthew",
-    "last": "adams",
-    "position": "wlb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "dadi nicolas",
-    "first": "dadi",
-    "last": "nicolas",
-    "position": "wlb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "obum gwacham",
-    "first": "obum",
-    "last": "gwacham",
-    "position": "wlb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "kenny moore",
-    "first": "kenny",
-    "last": "moore",
-    "position": "rcb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "quincy wilson",
-    "first": "quincy",
-    "last": "wilson",
-    "position": "rcb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "chris milton",
-    "first": "chris",
-    "last": "milton",
-    "position": "rcb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "shakial taylor",
-    "first": "shakial",
-    "last": "taylor",
-    "position": "rcb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "pierre desir",
-    "first": "pierre",
-    "last": "desir",
-    "position": "lcb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "rock ya-sin",
-    "first": "rock",
-    "last": "ya-sin",
-    "position": "lcb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "nate hairston",
-    "first": "nate",
-    "last": "hairston",
-    "position": "lcb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "jalen collins",
-    "first": "jalen",
-    "last": "collins",
-    "position": "lcb"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "clayton geathers",
-    "first": "clayton",
-    "last": "geathers",
-    "position": "ss"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "derrick kindred",
-    "first": "derrick",
-    "last": "kindred",
-    "position": "ss"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "rolan milligan",
-    "first": "rolan",
-    "last": "milligan",
-    "position": "ss"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "khari willis",
-    "first": "khari",
-    "last": "willis",
-    "position": "ss"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "matthias farley",
-    "first": "matthias",
-    "last": "farley",
-    "position": "ss"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "malik hooker",
-    "first": "malik",
-    "last": "hooker",
-    "position": "fs"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "marvell tell",
-    "first": "marvell",
-    "last": "tell",
-    "position": "fs"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "george odum",
-    "first": "george",
-    "last": "odum",
-    "position": "fs"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "isaiah johnson",
-    "first": "isaiah",
-    "last": "johnson",
-    "position": "fs"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "rigoberto sanchez",
-    "first": "rigoberto",
-    "last": "sanchez",
-    "position": "p"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "luke rhodes",
-    "first": "luke",
-    "last": "rhodes",
-    "position": "ls"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "rigoberto sanchez",
-    "first": "rigoberto",
-    "last": "sanchez",
-    "position": "h"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "adam vinatieri",
-    "first": "adam",
-    "last": "vinatieri",
-    "position": "k"
-  },
-  {
-    "team": "indianapolis colts",
-    "symbol": "IND",
-    "fullname": "cole hedlund",
-    "first": "cole",
-    "last": "hedlund",
-    "position": "k"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "russell wilson",
-    "first": "russell",
-    "last": "wilson",
-    "position": "qb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "geno smith",
-    "first": "geno",
-    "last": "smith",
-    "position": "qb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "paxton lynch",
-    "first": "paxton",
-    "last": "lynch",
-    "position": "qb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "chris carson",
-    "first": "chris",
-    "last": "carson",
-    "position": "rb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "rashaad penny",
-    "first": "rashaad",
-    "last": "penny",
-    "position": "rb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "j.d. mckissic",
-    "first": "j.d.",
-    "last": "mckissic",
-    "position": "rb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "c.j. prosise",
-    "first": "c.j.",
-    "last": "prosise",
-    "position": "rb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "travis homer",
-    "first": "travis",
-    "last": "homer",
-    "position": "rb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "bo scarbrough",
-    "first": "bo",
-    "last": "scarbrough",
-    "position": "rb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "marcelias sutton",
-    "first": "marcelias",
-    "last": "sutton",
-    "position": "rb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "adam choice",
-    "first": "adam",
-    "last": "choice",
-    "position": "rb"
+    "fullname": "spencer ware",
+    "first": "spencer",
+    "last": "ware",
+    "position": "fb"
   },
   {
     "team": "seattle seahawks",
@@ -7698,8 +2706,112 @@
   {
     "team": "seattle seahawks",
     "symbol": "SEA",
-    "fullname": "d.k. metcalf",
-    "first": "d.k.",
+    "fullname": "jaron brown",
+    "first": "jaron",
+    "last": "brown",
+    "position": "wr"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "chris carson",
+    "first": "chris",
+    "last": "carson",
+    "position": "rb"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "amara darboh",
+    "first": "amara",
+    "last": "darboh",
+    "position": "wr"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "ed dickson",
+    "first": "ed",
+    "last": "dickson",
+    "position": "te"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "will dissly",
+    "first": "will",
+    "last": "dissly",
+    "position": "te"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "jazz ferguson",
+    "first": "jazz",
+    "last": "ferguson",
+    "position": "wr"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "jackson harris",
+    "first": "jackson",
+    "last": "harris",
+    "position": "te"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "jacob hollister",
+    "first": "jacob",
+    "last": "hollister",
+    "position": "te"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "travis homer",
+    "first": "travis",
+    "last": "homer",
+    "position": "rb"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "gary jennings",
+    "first": "gary",
+    "last": "jennings",
+    "position": "wr"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "tyler lockett",
+    "first": "tyler",
+    "last": "lockett",
+    "position": "wr"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "paxton lynch",
+    "first": "paxton",
+    "last": "lynch",
+    "position": "qb"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "jd mckissic",
+    "first": "jd",
+    "last": "mckissic",
+    "position": "wr"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "dk metcalf",
+    "first": "dk",
     "last": "metcalf",
     "position": "wr"
   },
@@ -7714,42 +2826,26 @@
   {
     "team": "seattle seahawks",
     "symbol": "SEA",
-    "fullname": "gary jennings",
-    "first": "gary",
-    "last": "jennings",
-    "position": "wr"
+    "fullname": "jason myers",
+    "first": "jason",
+    "last": "myers",
+    "position": "k"
   },
   {
     "team": "seattle seahawks",
     "symbol": "SEA",
-    "fullname": "jaron brown",
-    "first": "jaron",
-    "last": "brown",
-    "position": "wr"
+    "fullname": "rashaad penny",
+    "first": "rashaad",
+    "last": "penny",
+    "position": "rb"
   },
   {
     "team": "seattle seahawks",
     "symbol": "SEA",
-    "fullname": "john ursua",
-    "first": "john",
-    "last": "ursua",
-    "position": "wr"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "malik turner",
-    "first": "malik",
-    "last": "turner",
-    "position": "wr"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "amara darboh",
-    "first": "amara",
-    "last": "darboh",
-    "position": "wr"
+    "fullname": "cj prosise",
+    "first": "cj",
+    "last": "prosise",
+    "position": "rb"
   },
   {
     "team": "seattle seahawks",
@@ -7762,34 +2858,50 @@
   {
     "team": "seattle seahawks",
     "symbol": "SEA",
-    "fullname": "caleb scott",
-    "first": "caleb",
-    "last": "scott",
-    "position": "wr"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "terry wright",
-    "first": "terry",
-    "last": "wright",
-    "position": "wr"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jazz ferguson",
-    "first": "jazz",
-    "last": "ferguson",
-    "position": "wr"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "will dissly",
-    "first": "will",
-    "last": "dissly",
+    "fullname": "wes saxton",
+    "first": "wes",
+    "last": "saxton",
     "position": "te"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "bo scarbrough",
+    "first": "bo",
+    "last": "scarbrough",
+    "position": "rb"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "geno smith",
+    "first": "geno",
+    "last": "smith",
+    "position": "qb"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "malik turner",
+    "first": "malik",
+    "last": "turner",
+    "position": "wr"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "xavier turner",
+    "first": "xavier",
+    "last": "turner",
+    "position": "rb"
+  },
+  {
+    "team": "seattle seahawks",
+    "symbol": "SEA",
+    "fullname": "john ursua",
+    "first": "john",
+    "last": "ursua",
+    "position": "wr"
   },
   {
     "team": "seattle seahawks",
@@ -7802,34 +2914,26 @@
   {
     "team": "seattle seahawks",
     "symbol": "SEA",
-    "fullname": "george fant",
-    "first": "george",
-    "last": "fant",
-    "position": "te"
+    "fullname": "russell wilson",
+    "first": "russell",
+    "last": "wilson",
+    "position": "qb"
   },
   {
     "team": "seattle seahawks",
     "symbol": "SEA",
-    "fullname": "ed dickson",
-    "first": "ed",
-    "last": "dickson",
-    "position": "te"
+    "fullname": "terry wright",
+    "first": "terry",
+    "last": "wright",
+    "position": "wr"
   },
   {
     "team": "seattle seahawks",
     "symbol": "SEA",
-    "fullname": "jacob hollister",
-    "first": "jacob",
-    "last": "hollister",
-    "position": "te"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "tyrone swoopes",
-    "first": "tyrone",
-    "last": "swoopes",
-    "position": "te"
+    "fullname": "adam choice",
+    "first": "adam",
+    "last": "choice",
+    "position": "rb"
   },
   {
     "team": "seattle seahawks",
@@ -7842,705 +2946,9 @@
   {
     "team": "seattle seahawks",
     "symbol": "SEA",
-    "fullname": "duane brown",
-    "first": "duane",
-    "last": "brown",
-    "position": "lt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "george fant",
-    "first": "george",
-    "last": "fant",
-    "position": "lt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jamarco jones",
-    "first": "jamarco",
-    "last": "jones",
-    "position": "lt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "mike iupati",
-    "first": "mike",
-    "last": "iupati",
-    "position": "lg"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jordan simmons",
-    "first": "jordan",
-    "last": "simmons",
-    "position": "lg"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "phil haynes",
-    "first": "phil",
-    "last": "haynes",
-    "position": "lg"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "justin britt",
-    "first": "justin",
-    "last": "britt",
-    "position": "c"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "joey hunt",
-    "first": "joey",
-    "last": "hunt",
-    "position": "c"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "d.j. fluker",
-    "first": "d.j.",
-    "last": "fluker",
-    "position": "rg"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "ethan pocic",
-    "first": "ethan",
-    "last": "pocic",
-    "position": "rg"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jordan roos",
-    "first": "jordan",
-    "last": "roos",
-    "position": "rg"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "marcus martin",
-    "first": "marcus",
-    "last": "martin",
-    "position": "rg"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "germain ifedi",
-    "first": "germain",
-    "last": "ifedi",
-    "position": "rt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "george fant",
-    "first": "george",
-    "last": "fant",
-    "position": "rt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "elijah nkansah",
-    "first": "elijah",
-    "last": "nkansah",
-    "position": "rt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jarran reed",
-    "first": "jarran",
-    "last": "reed",
-    "position": "ldt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "demarcus christmas",
-    "first": "demarcus",
-    "last": "christmas",
-    "position": "ldt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jay-tee tiuli",
-    "first": "jay-tee",
-    "last": "tiuli",
-    "position": "ldt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "al woods",
-    "first": "al",
-    "last": "woods",
-    "position": "ldt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "quinton jefferson",
-    "first": "quinton",
-    "last": "jefferson",
-    "position": "lde"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "cassius marsh",
-    "first": "cassius",
-    "last": "marsh",
-    "position": "lde"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "rasheem green",
-    "first": "rasheem",
-    "last": "green",
-    "position": "lde"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "poona ford",
-    "first": "poona",
-    "last": "ford",
-    "position": "rdt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jamie meder",
-    "first": "jamie",
-    "last": "meder",
-    "position": "rdt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "bryan mone",
-    "first": "bryan",
-    "last": "mone",
-    "position": "rdt"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "ezekiel ansah",
-    "first": "ezekiel",
-    "last": "ansah",
-    "position": "rde"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "l.j. collier",
-    "first": "l.j.",
-    "last": "collier",
-    "position": "rde"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "nazair jones",
-    "first": "nazair",
-    "last": "jones",
-    "position": "rde"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "branden jackson",
-    "first": "branden",
-    "last": "jackson",
-    "position": "rde"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "bobby wagner",
-    "first": "bobby",
-    "last": "wagner",
-    "position": "mlb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "austin calitro",
-    "first": "austin",
-    "last": "calitro",
-    "position": "mlb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "ben burr-kirven",
-    "first": "ben",
-    "last": "burr-kirven",
-    "position": "mlb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "emmanuel ellerbee",
-    "first": "emmanuel",
-    "last": "ellerbee",
-    "position": "mlb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "k.j. wright",
-    "first": "k.j.",
-    "last": "wright",
-    "position": "slb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "shaquem griffin",
-    "first": "shaquem",
-    "last": "griffin",
-    "position": "slb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "cody barton",
-    "first": "cody",
-    "last": "barton",
-    "position": "slb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "justin currie",
-    "first": "justin",
-    "last": "currie",
-    "position": "slb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "barkevious mingo",
-    "first": "barkevious",
-    "last": "mingo",
-    "position": "wlb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "mychal kendricks",
-    "first": "mychal",
-    "last": "kendricks",
-    "position": "wlb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jake martin",
-    "first": "jake",
-    "last": "martin",
-    "position": "wlb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "tre flowers",
-    "first": "tre",
-    "last": "flowers",
-    "position": "rcb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jamar taylor",
-    "first": "jamar",
-    "last": "taylor",
-    "position": "rcb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "akeem king",
-    "first": "akeem",
-    "last": "king",
-    "position": "rcb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "kalan reed",
-    "first": "kalan",
-    "last": "reed",
-    "position": "rcb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "simeon thomas",
-    "first": "simeon",
-    "last": "thomas",
-    "position": "rcb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "shaquill griffin",
-    "first": "shaquill",
-    "last": "griffin",
-    "position": "lcb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "neiko thorpe",
-    "first": "neiko",
-    "last": "thorpe",
-    "position": "lcb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jeremy boykins",
-    "first": "jeremy",
-    "last": "boykins",
-    "position": "lcb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "davante davis",
-    "first": "davante",
-    "last": "davis",
-    "position": "lcb"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "bradley mcdougald",
-    "first": "bradley",
-    "last": "mcdougald",
-    "position": "ss"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "ugo amadi",
-    "first": "ugo",
-    "last": "amadi",
-    "position": "ss"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "marwin evans",
-    "first": "marwin",
-    "last": "evans",
-    "position": "ss"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "shalom luani",
-    "first": "shalom",
-    "last": "luani",
-    "position": "ss"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "tedric thompson",
-    "first": "tedric",
-    "last": "thompson",
-    "position": "fs"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "marquise blair",
-    "first": "marquise",
-    "last": "blair",
-    "position": "fs"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "delano hill",
-    "first": "delano",
-    "last": "hill",
-    "position": "fs"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jalen harvey",
-    "first": "jalen",
-    "last": "harvey",
-    "position": "fs"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "michael dickson",
-    "first": "michael",
-    "last": "dickson",
-    "position": "p"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "tyler ott",
-    "first": "tyler",
-    "last": "ott",
-    "position": "ls"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "tyler lockett",
-    "first": "tyler",
-    "last": "lockett",
-    "position": "wr"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "michael dickson",
-    "first": "michael",
-    "last": "dickson",
-    "position": "h"
-  },
-  {
-    "team": "seattle seahawks",
-    "symbol": "SEA",
-    "fullname": "jason myers",
-    "first": "jason",
-    "last": "myers",
-    "position": "k"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "patrick mahomes",
-    "first": "patrick",
-    "last": "mahomes",
-    "position": "qb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "chad henne",
-    "first": "chad",
-    "last": "henne",
-    "position": "qb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "chase litton",
-    "first": "chase",
-    "last": "litton",
-    "position": "qb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "kyle shurmur",
-    "first": "kyle",
-    "last": "shurmur",
-    "position": "qb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "john lovett",
-    "first": "john",
-    "last": "lovett",
-    "position": "qb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "damien williams",
-    "first": "damien",
-    "last": "williams",
-    "position": "rb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "carlos hyde",
-    "first": "carlos",
-    "last": "hyde",
-    "position": "rb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "darwin thompson",
-    "first": "darwin",
-    "last": "thompson",
-    "position": "rb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "darrel williams",
-    "first": "darrel",
-    "last": "williams",
-    "position": "rb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "marcus marshall",
-    "first": "marcus",
-    "last": "marshall",
-    "position": "rb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "josh caldwell",
-    "first": "josh",
-    "last": "caldwell",
-    "position": "rb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "anthony sherman",
-    "first": "anthony",
-    "last": "sherman",
-    "position": "fb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "tyreek hill",
-    "first": "tyreek",
-    "last": "hill",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "sammy watkins",
-    "first": "sammy",
-    "last": "watkins",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "mecole hardman",
-    "first": "mecole",
-    "last": "hardman",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "demarcus robinson",
-    "first": "demarcus",
-    "last": "robinson",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "marcus kemp",
-    "first": "marcus",
-    "last": "kemp",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "gehrig dieter",
-    "first": "gehrig",
-    "last": "dieter",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "byron pringle",
-    "first": "byron",
-    "last": "pringle",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "davon grayson",
-    "first": "davon",
-    "last": "grayson",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "jamal custis",
-    "first": "jamal",
-    "last": "custis",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "cody thompson",
-    "first": "cody",
-    "last": "thompson",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "felton davis",
-    "first": "felton",
-    "last": "davis",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "rashard davis",
-    "first": "rashard",
-    "last": "davis",
-    "position": "wr"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "travis kelce",
-    "first": "travis",
-    "last": "kelce",
+    "fullname": "tyrone swoopes",
+    "first": "tyrone",
+    "last": "swoopes",
     "position": "te"
   },
   {
@@ -8554,26 +2962,98 @@
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "deon yelder",
-    "first": "deon",
-    "last": "yelder",
-    "position": "te"
+    "fullname": "harrison butker",
+    "first": "harrison",
+    "last": "butker",
+    "position": "k"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "david wells",
-    "first": "david",
-    "last": "wells",
-    "position": "te"
+    "fullname": "josh caldwell",
+    "first": "josh",
+    "last": "caldwell",
+    "position": "rb"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "jody fortson",
-    "first": "jody",
+    "fullname": "jamal custis",
+    "first": "jamal",
+    "last": "custis",
+    "position": "wr"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "rashard davis",
+    "first": "rashard",
+    "last": "davis",
+    "position": "wr"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "felton davis iii",
+    "first": "felton",
+    "last": "davis iii",
+    "position": "wr"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "gehrig dieter",
+    "first": "gehrig",
+    "last": "dieter",
+    "position": "wr"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "joe fortson",
+    "first": "joe",
     "last": "fortson",
-    "position": "te"
+    "position": "wr"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "davon grayson",
+    "first": "davon",
+    "last": "grayson",
+    "position": "wr"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "mecole hardman",
+    "first": "mecole",
+    "last": "hardman",
+    "position": "wr"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "chad henne",
+    "first": "chad",
+    "last": "henne",
+    "position": "qb"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "tyreek hill",
+    "first": "tyreek",
+    "last": "hill",
+    "position": "wr"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "carlos hyde",
+    "first": "carlos",
+    "last": "hyde",
+    "position": "rb"
   },
   {
     "team": "kansas city chiefs",
@@ -8586,506 +3066,146 @@
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "eric fisher",
-    "first": "eric",
-    "last": "fisher",
-    "position": "lt"
+    "fullname": "travis kelce",
+    "first": "travis",
+    "last": "kelce",
+    "position": "te"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "cameron erving",
-    "first": "cameron",
-    "last": "erving",
-    "position": "lt"
+    "fullname": "marcus kemp",
+    "first": "marcus",
+    "last": "kemp",
+    "position": "wr"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "pace murphy",
-    "first": "pace",
-    "last": "murphy",
-    "position": "lt"
+    "fullname": "chase litton",
+    "first": "chase",
+    "last": "litton",
+    "position": "qb"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "cameron erving",
-    "first": "cameron",
-    "last": "erving",
-    "position": "lg"
+    "fullname": "john lovett",
+    "first": "john",
+    "last": "lovett",
+    "position": "qb"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "kahlil mckenzie",
-    "first": "kahlil",
-    "last": "mckenzie",
-    "position": "lg"
+    "fullname": "patrick mahomes ii",
+    "first": "patrick",
+    "last": "mahomes ii",
+    "position": "qb"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "austin reiter",
-    "first": "austin",
-    "last": "reiter",
-    "position": "c"
+    "fullname": "marcus marshall",
+    "first": "marcus",
+    "last": "marshall",
+    "position": "rb"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "nick allegretti",
-    "first": "nick",
-    "last": "allegretti",
-    "position": "c"
+    "fullname": "byron pringle",
+    "first": "byron",
+    "last": "pringle",
+    "position": "wr"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "james murray",
-    "first": "james",
-    "last": "murray",
-    "position": "c"
+    "fullname": "demarcus robinson",
+    "first": "demarcus",
+    "last": "robinson",
+    "position": "wr"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "laurent duvernay-tardif",
-    "first": "laurent",
-    "last": "duvernay-tardif",
-    "position": "rg"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "andrew wylie",
-    "first": "andrew",
-    "last": "wylie",
-    "position": "rg"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "mitchell schwartz",
-    "first": "mitchell",
-    "last": "schwartz",
-    "position": "rt"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "ryan hunter",
-    "first": "ryan",
-    "last": "hunter",
-    "position": "rt"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "chidi okeke",
-    "first": "chidi",
-    "last": "okeke",
-    "position": "rt"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "derrick nnadi",
-    "first": "derrick",
-    "last": "nnadi",
-    "position": "ldt"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "xavier williams",
-    "first": "xavier",
-    "last": "williams",
-    "position": "ldt"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "khalen saunders",
-    "first": "khalen",
-    "last": "saunders",
-    "position": "ldt"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "alex okafor",
-    "first": "alex",
-    "last": "okafor",
-    "position": "lde"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "emmanuel ogbah",
-    "first": "emmanuel",
-    "last": "ogbah",
-    "position": "lde"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "tanoh kpassagnon",
-    "first": "tanoh",
-    "last": "kpassagnon",
-    "position": "lde"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "cavon walker",
-    "first": "cavon",
-    "last": "walker",
-    "position": "lde"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "chris jones",
-    "first": "chris",
-    "last": "jones",
-    "position": "rdt"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "justin hamilton",
-    "first": "justin",
-    "last": "hamilton",
-    "position": "rdt"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "joey ivie",
-    "first": "joey",
-    "last": "ivie",
-    "position": "rdt"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "frank clark",
-    "first": "frank",
-    "last": "clark",
-    "position": "rde"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "breeland speaks",
-    "first": "breeland",
-    "last": "speaks",
-    "position": "rde"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "anthony hitchens",
+    "fullname": "anthony sherman",
     "first": "anthony",
-    "last": "hitchens",
-    "position": "mlb"
+    "last": "sherman",
+    "position": "fb"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "ben niemann",
-    "first": "ben",
-    "last": "niemann",
-    "position": "mlb"
+    "fullname": "kyle shurmur",
+    "first": "kyle",
+    "last": "shurmur",
+    "position": "qb"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "robert mccray",
-    "first": "robert",
-    "last": "mccray",
-    "position": "mlb"
+    "fullname": "cody thompson",
+    "first": "cody",
+    "last": "thompson",
+    "position": "wr"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "andrew soroh",
-    "first": "andrew",
-    "last": "soroh",
-    "position": "mlb"
+    "fullname": "darwin thompson",
+    "first": "darwin",
+    "last": "thompson",
+    "position": "rb"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "damien wilson",
+    "fullname": "sammy watkins",
+    "first": "sammy",
+    "last": "watkins",
+    "position": "wr"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "david wells",
+    "first": "david",
+    "last": "wells",
+    "position": "te"
+  },
+  {
+    "team": "kansas city chiefs",
+    "symbol": "KC",
+    "fullname": "damien williams",
     "first": "damien",
-    "last": "wilson",
-    "position": "slb"
+    "last": "williams",
+    "position": "rb"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "jeremiah attaochu",
-    "first": "jeremiah",
-    "last": "attaochu",
-    "position": "slb"
+    "fullname": "darrel williams",
+    "first": "darrel",
+    "last": "williams",
+    "position": "rb"
   },
   {
     "team": "kansas city chiefs",
     "symbol": "KC",
-    "fullname": "raymond davison",
-    "first": "raymond",
-    "last": "davison",
-    "position": "slb"
+    "fullname": "deon yelder",
+    "first": "deon",
+    "last": "yelder",
+    "position": "te"
   },
   {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "darius harris",
-    "first": "darius",
-    "last": "harris",
-    "position": "slb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "reggie ragland",
-    "first": "reggie",
-    "last": "ragland",
-    "position": "wlb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "darron lee",
-    "first": "darron",
-    "last": "lee",
-    "position": "wlb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "dorian o'daniel",
-    "first": "dorian",
-    "last": "o'daniel",
-    "position": "wlb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "d'juan hines",
-    "first": "d'juan",
-    "last": "hines",
-    "position": "wlb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "kendall fuller",
-    "first": "kendall",
-    "last": "fuller",
-    "position": "rcb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "charvarius ward",
-    "first": "charvarius",
-    "last": "ward",
-    "position": "rcb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "tremon smith",
-    "first": "tremon",
-    "last": "smith",
-    "position": "rcb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "rashad fenton",
-    "first": "rashad",
-    "last": "fenton",
-    "position": "rcb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "herb miller",
-    "first": "herb",
-    "last": "miller",
-    "position": "rcb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "bashaud breeland",
-    "first": "bashaud",
-    "last": "breeland",
-    "position": "lcb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "keith reaser",
-    "first": "keith",
-    "last": "reaser",
-    "position": "lcb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "mark fields",
-    "first": "mark",
-    "last": "fields",
-    "position": "lcb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "d'montre wade",
-    "first": "d'montre",
-    "last": "wade",
-    "position": "lcb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "dakari monroe",
-    "first": "dakari",
-    "last": "monroe",
-    "position": "lcb"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "tyrann mathieu",
-    "first": "tyrann",
-    "last": "mathieu",
-    "position": "ss"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "daniel sorensen",
-    "first": "daniel",
-    "last": "sorensen",
-    "position": "ss"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "armani watts",
-    "first": "armani",
-    "last": "watts",
-    "position": "ss"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "jordan lucas",
-    "first": "jordan",
-    "last": "lucas",
-    "position": "fs"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "juan thornhill",
-    "first": "juan",
-    "last": "thornhill",
-    "position": "fs"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "harold jones-quartey",
-    "first": "harold",
-    "last": "jones-quartey",
-    "position": "fs"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "dustin colquitt",
-    "first": "dustin",
-    "last": "colquitt",
-    "position": "p"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "jack fox",
-    "first": "jack",
-    "last": "fox",
-    "position": "p"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "james winchester",
-    "first": "james",
-    "last": "winchester",
-    "position": "ls"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "dustin colquitt",
-    "first": "dustin",
-    "last": "colquitt",
-    "position": "h"
-  },
-  {
-    "team": "kansas city chiefs",
-    "symbol": "KC",
-    "fullname": "harrison butker",
-    "first": "harrison",
-    "last": "butker",
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "chris boswell",
+    "first": "chris",
+    "last": "boswell",
     "position": "k"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "ben roethlisberger",
-    "first": "ben",
-    "last": "roethlisberger",
-    "position": "qb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "joshua dobbs",
-    "first": "joshua",
-    "last": "dobbs",
-    "position": "qb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "mason rudolph",
-    "first": "mason",
-    "last": "rudolph",
-    "position": "qb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "devlin hodges",
-    "first": "devlin",
-    "last": "hodges",
-    "position": "qb"
   },
   {
     "team": "pittsburgh steelers",
@@ -9098,18 +3218,10 @@
   {
     "team": "pittsburgh steelers",
     "symbol": "PIT",
-    "fullname": "jaylen samuels",
-    "first": "jaylen",
-    "last": "samuels",
-    "position": "rb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "benny snell",
-    "first": "benny",
-    "last": "snell",
-    "position": "rb"
+    "fullname": "joshua dobbs",
+    "first": "joshua",
+    "last": "dobbs",
+    "position": "qb"
   },
   {
     "team": "pittsburgh steelers",
@@ -9117,134 +3229,6 @@
     "fullname": "trey edmunds",
     "first": "trey",
     "last": "edmunds",
-    "position": "rb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "ralph webb",
-    "first": "ralph",
-    "last": "webb",
-    "position": "rb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "malik williams",
-    "first": "malik",
-    "last": "williams",
-    "position": "rb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "travon mcmillian",
-    "first": "travon",
-    "last": "mcmillian",
-    "position": "rb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "roosevelt nix-jones",
-    "first": "roosevelt",
-    "last": "nix-jones",
-    "position": "fb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "juju smith-schuster",
-    "first": "juju",
-    "last": "smith-schuster",
-    "position": "wr"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "donte moncrief",
-    "first": "donte",
-    "last": "moncrief",
-    "position": "wr"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "james washington",
-    "first": "james",
-    "last": "washington",
-    "position": "wr"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "eli rogers",
-    "first": "eli",
-    "last": "rogers",
-    "position": "wr"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "diontae johnson",
-    "first": "diontae",
-    "last": "johnson",
-    "position": "wr"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "ryan switzer",
-    "first": "ryan",
-    "last": "switzer",
-    "position": "wr"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "trey griffey",
-    "first": "trey",
-    "last": "griffey",
-    "position": "wr"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "johnny holton",
-    "first": "johnny",
-    "last": "holton",
-    "position": "wr"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "tevin jones",
-    "first": "tevin",
-    "last": "jones",
-    "position": "wr"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "diontae spencer",
-    "first": "diontae",
-    "last": "spencer",
-    "position": "wr"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "vance mcdonald",
-    "first": "vance",
-    "last": "mcdonald",
-    "position": "te"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "xavier grimble",
-    "first": "xavier",
-    "last": "grimble",
     "position": "te"
   },
   {
@@ -9258,10 +3242,130 @@
   {
     "team": "pittsburgh steelers",
     "symbol": "PIT",
+    "fullname": "trey griffey",
+    "first": "trey",
+    "last": "griffey",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "xavier grimble",
+    "first": "xavier",
+    "last": "grimble",
+    "position": "te"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "devlin hodges",
+    "first": "devlin",
+    "last": "hodges",
+    "position": "qb"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "johnny holton",
+    "first": "johnny",
+    "last": "holton",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "diontae johnson",
+    "first": "diontae",
+    "last": "johnson",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "tevin jones",
+    "first": "tevin",
+    "last": "jones",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "vance mcdonald",
+    "first": "vance",
+    "last": "mcdonald",
+    "position": "te"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "travon mcmillian",
+    "first": "travon",
+    "last": "mcmillian",
+    "position": "rb"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "donte moncrief",
+    "first": "donte",
+    "last": "moncrief",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "roosevelt nix",
+    "first": "roosevelt",
+    "last": "nix",
+    "position": "fb"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
     "fullname": "kevin rader",
     "first": "kevin",
     "last": "rader",
     "position": "te"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "brandon reilly",
+    "first": "brandon",
+    "last": "reilly",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "ben roethlisberger",
+    "first": "ben",
+    "last": "roethlisberger",
+    "position": "qb"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "eli rogers",
+    "first": "eli",
+    "last": "rogers",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "mason rudolph",
+    "first": "mason",
+    "last": "rudolph",
+    "position": "qb"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "jaylen samuels",
+    "first": "jaylen",
+    "last": "samuels",
+    "position": "fb"
   },
   {
     "team": "pittsburgh steelers",
@@ -9274,6 +3378,54 @@
   {
     "team": "pittsburgh steelers",
     "symbol": "PIT",
+    "fullname": "juju smith-schuster",
+    "first": "juju",
+    "last": "smith-schuster",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "benny snell jr.",
+    "first": "benny",
+    "last": "snell jr.",
+    "position": "rb"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "diontae spencer",
+    "first": "diontae",
+    "last": "spencer",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "ryan switzer",
+    "first": "ryan",
+    "last": "switzer",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "james washington",
+    "first": "james",
+    "last": "washington",
+    "position": "wr"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
+    "fullname": "malik williams",
+    "first": "malik",
+    "last": "williams",
+    "position": "rb"
+  },
+  {
+    "team": "pittsburgh steelers",
+    "symbol": "PIT",
     "fullname": "trevor wood",
     "first": "trevor",
     "last": "wood",
@@ -9282,450 +3434,18 @@
   {
     "team": "pittsburgh steelers",
     "symbol": "PIT",
-    "fullname": "alejandro villanueva",
-    "first": "alejandro",
-    "last": "villanueva",
-    "position": "lt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "chukwuma okorafor",
-    "first": "chukwuma",
-    "last": "okorafor",
-    "position": "lt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "derwin gray",
-    "first": "derwin",
-    "last": "gray",
-    "position": "lt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "ramon foster",
-    "first": "ramon",
-    "last": "foster",
-    "position": "lg"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "maurkice pouncey",
-    "first": "maurkice",
-    "last": "pouncey",
-    "position": "c"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "b.j. finney",
-    "first": "b.j.",
-    "last": "finney",
-    "position": "c"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "j.c. hassenauer",
-    "first": "j.c.",
-    "last": "hassenauer",
-    "position": "c"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "david decastro",
-    "first": "david",
-    "last": "decastro",
-    "position": "rg"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "fred johnson",
-    "first": "fred",
-    "last": "johnson",
-    "position": "rg"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "matt feiler",
-    "first": "matt",
-    "last": "feiler",
-    "position": "rt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "jerald hawkins",
-    "first": "jerald",
-    "last": "hawkins",
-    "position": "rt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "zach banner",
-    "first": "zach",
-    "last": "banner",
-    "position": "rt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "damian prince",
-    "first": "damian",
-    "last": "prince",
-    "position": "rt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "cameron heyward",
-    "first": "cameron",
-    "last": "heyward",
-    "position": "lde"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "isaiah buggs",
-    "first": "isaiah",
-    "last": "buggs",
-    "position": "lde"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "conor sheehy",
-    "first": "conor",
-    "last": "sheehy",
-    "position": "lde"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "winston craig",
-    "first": "winston",
-    "last": "craig",
-    "position": "lde"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "javon hargrave",
-    "first": "javon",
-    "last": "hargrave",
-    "position": "ndt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "dan mccullers-sanders",
-    "first": "dan",
-    "last": "mccullers-sanders",
-    "position": "ndt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "lavon hooks",
-    "first": "lavon",
-    "last": "hooks",
-    "position": "ndt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "greg gilmore",
-    "first": "greg",
-    "last": "gilmore",
-    "position": "ndt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "stephon tuitt",
-    "first": "stephon",
-    "last": "tuitt",
-    "position": "rde"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "tyson alualu",
-    "first": "tyson",
-    "last": "alualu",
-    "position": "rde"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "henry mondeaux",
-    "first": "henry",
-    "last": "mondeaux",
-    "position": "rde"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "t.j. watt",
-    "first": "t.j.",
-    "last": "watt",
-    "position": "slb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "anthony chickillo",
-    "first": "anthony",
-    "last": "chickillo",
-    "position": "slb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "sutton smith",
-    "first": "sutton",
-    "last": "smith",
-    "position": "slb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "jt jones",
-    "first": "jt",
-    "last": "jones",
-    "position": "slb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "bud dupree",
-    "first": "bud",
-    "last": "dupree",
-    "position": "wlb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "ola adeniyi",
-    "first": "ola",
-    "last": "adeniyi",
-    "position": "wlb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "tuzar skipper",
-    "first": "tuzar",
-    "last": "skipper",
-    "position": "wlb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "steven nelson",
-    "first": "steven",
-    "last": "nelson",
-    "position": "rcb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "artie burns",
-    "first": "artie",
-    "last": "burns",
-    "position": "rcb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "cameron sutton",
-    "first": "cameron",
-    "last": "sutton",
-    "position": "rcb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "marcelis branch",
-    "first": "marcelis",
-    "last": "branch",
-    "position": "rcb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "kam kelly",
-    "first": "kam",
-    "last": "kelly",
-    "position": "rcb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "joe haden",
-    "first": "joe",
-    "last": "haden",
-    "position": "lcb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "mike hilton",
-    "first": "mike",
-    "last": "hilton",
-    "position": "lcb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "justin layne",
-    "first": "justin",
-    "last": "layne",
-    "position": "lcb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "herb waters",
-    "first": "herb",
-    "last": "waters",
-    "position": "lcb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "alexander myres",
-    "first": "alexander",
-    "last": "myres",
-    "position": "lcb"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "terrell edmunds",
-    "first": "terrell",
-    "last": "edmunds",
-    "position": "ss"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "jordan dangerfield",
-    "first": "jordan",
-    "last": "dangerfield",
-    "position": "ss"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "dravon askew-henry",
-    "first": "dravon",
-    "last": "askew-henry",
-    "position": "ss"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "sean davis",
-    "first": "sean",
-    "last": "davis",
-    "position": "fs"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "marcus allen",
-    "first": "marcus",
-    "last": "allen",
-    "position": "fs"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "brian allen",
-    "first": "brian",
-    "last": "allen",
-    "position": "fs"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "jordan berry",
-    "first": "jordan",
-    "last": "berry",
-    "position": "p"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "ian berryman",
-    "first": "ian",
-    "last": "berryman",
-    "position": "p"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "kameron canaday",
-    "first": "kameron",
-    "last": "canaday",
-    "position": "ls"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "jordan berry",
-    "first": "jordan",
-    "last": "berry",
-    "position": "h"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
-    "fullname": "chris boswell",
-    "first": "chris",
-    "last": "boswell",
-    "position": "k"
-  },
-  {
-    "team": "pittsburgh steelers",
-    "symbol": "PIT",
     "fullname": "matthew wright",
     "first": "matthew",
     "last": "wright",
     "position": "k"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "dan arnold",
+    "first": "dan",
+    "last": "arnold",
+    "position": "te"
   },
   {
     "team": "new orleans saints",
@@ -9746,113 +3466,17 @@
   {
     "team": "new orleans saints",
     "symbol": "NO",
-    "fullname": "taysom hill",
-    "first": "taysom",
-    "last": "hill",
-    "position": "qb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "j.t. barrett",
-    "first": "j.t.",
-    "last": "barrett",
-    "position": "qb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "alvin kamara",
-    "first": "alvin",
-    "last": "kamara",
-    "position": "rb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "latavius murray",
-    "first": "latavius",
-    "last": "murray",
-    "position": "rb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "dwayne washington",
-    "first": "dwayne",
-    "last": "washington",
-    "position": "rb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "javorius allen",
-    "first": "javorius",
-    "last": "allen",
-    "position": "rb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "devine ozigbo",
-    "first": "devine",
-    "last": "ozigbo",
-    "position": "rb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "matt dayes",
-    "first": "matt",
-    "last": "dayes",
-    "position": "rb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "zach line",
-    "first": "zach",
-    "last": "line",
-    "position": "fb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "michael burton",
-    "first": "michael",
+    "fullname": "mike burton",
+    "first": "mike",
     "last": "burton",
     "position": "fb"
   },
   {
     "team": "new orleans saints",
     "symbol": "NO",
-    "fullname": "michael thomas",
-    "first": "michael",
-    "last": "thomas",
-    "position": "wr"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "ted ginn",
-    "first": "ted",
-    "last": "ginn",
-    "position": "wr"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "tre'quan smith",
-    "first": "tre'quan",
-    "last": "smith",
-    "position": "wr"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "keith kirkwood",
-    "first": "keith",
-    "last": "kirkwood",
+    "fullname": "emmanuel butler",
+    "first": "emmanuel",
+    "last": "butler",
     "position": "wr"
   },
   {
@@ -9866,57 +3490,9 @@
   {
     "team": "new orleans saints",
     "symbol": "NO",
-    "fullname": "cameron meredith",
-    "first": "cameron",
-    "last": "meredith",
-    "position": "wr"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "simmie cobbs",
+    "fullname": "simmie cobbs jr.",
     "first": "simmie",
-    "last": "cobbs",
-    "position": "wr"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "emmanuel butler",
-    "first": "emmanuel",
-    "last": "butler",
-    "position": "wr"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "deonte harris",
-    "first": "deonte",
-    "last": "harris",
-    "position": "wr"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "cyril grayson",
-    "first": "cyril",
-    "last": "grayson",
-    "position": "wr"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "lil'jordan humphrey",
-    "first": "lil'jordan",
-    "last": "humphrey",
-    "position": "wr"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "chad hansen",
-    "first": "chad",
-    "last": "hansen",
+    "last": "cobbs jr.",
     "position": "wr"
   },
   {
@@ -9930,18 +3506,34 @@
   {
     "team": "new orleans saints",
     "symbol": "NO",
-    "fullname": "josh hill",
-    "first": "josh",
-    "last": "hill",
+    "fullname": "aj derby",
+    "first": "aj",
+    "last": "derby",
     "position": "te"
   },
   {
     "team": "new orleans saints",
     "symbol": "NO",
-    "fullname": "dan arnold",
-    "first": "dan",
-    "last": "arnold",
-    "position": "te"
+    "fullname": "travin dural",
+    "first": "travin",
+    "last": "dural",
+    "position": "wr"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "ted ginn",
+    "first": "ted",
+    "last": "ginn",
+    "position": "wr"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "cyril grayson",
+    "first": "cyril",
+    "last": "grayson",
+    "position": "wr"
   },
   {
     "team": "new orleans saints",
@@ -9954,466 +3546,18 @@
   {
     "team": "new orleans saints",
     "symbol": "NO",
-    "fullname": "alize mack",
-    "first": "alize",
-    "last": "mack",
+    "fullname": "deonte harris",
+    "first": "deonte",
+    "last": "harris",
+    "position": "wr"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "josh hill",
+    "first": "josh",
+    "last": "hill",
     "position": "te"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "terron armstead",
-    "first": "terron",
-    "last": "armstead",
-    "position": "lt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "michael ola",
-    "first": "michael",
-    "last": "ola",
-    "position": "lt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "ethan greenidge",
-    "first": "ethan",
-    "last": "greenidge",
-    "position": "lt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "andrus peat",
-    "first": "andrus",
-    "last": "peat",
-    "position": "lg"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "ryan groy",
-    "first": "ryan",
-    "last": "groy",
-    "position": "lg"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "cameron tom",
-    "first": "cameron",
-    "last": "tom",
-    "position": "lg"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "erik mccoy",
-    "first": "erik",
-    "last": "mccoy",
-    "position": "c"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "erik mccoy",
-    "first": "erik",
-    "last": "mccoy",
-    "position": "c"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "marcus henry",
-    "first": "marcus",
-    "last": "henry",
-    "position": "c"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "larry warford",
-    "first": "larry",
-    "last": "warford",
-    "position": "rg"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "will clapp",
-    "first": "will",
-    "last": "clapp",
-    "position": "rg"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "ryan ramczyk",
-    "first": "ryan",
-    "last": "ramczyk",
-    "position": "rt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "marshall newhouse",
-    "first": "marshall",
-    "last": "newhouse",
-    "position": "rt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "ulrick john",
-    "first": "ulrick",
-    "last": "john",
-    "position": "rt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "sheldon rankins",
-    "first": "sheldon",
-    "last": "rankins",
-    "position": "ldt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "david onyemata",
-    "first": "david",
-    "last": "onyemata",
-    "position": "ldt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "shy tuttle",
-    "first": "shy",
-    "last": "tuttle",
-    "position": "ldt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "sylvester williams",
-    "first": "sylvester",
-    "last": "williams",
-    "position": "ldt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "cameron jordan",
-    "first": "cameron",
-    "last": "jordan",
-    "position": "lde"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "trey hendrickson",
-    "first": "trey",
-    "last": "hendrickson",
-    "position": "lde"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "corbin kaufusi",
-    "first": "corbin",
-    "last": "kaufusi",
-    "position": "lde"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "geneo grissom",
-    "first": "geneo",
-    "last": "grissom",
-    "position": "lde"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "malcom brown",
-    "first": "malcom",
-    "last": "brown",
-    "position": "rdt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "taylor stallworth",
-    "first": "taylor",
-    "last": "stallworth",
-    "position": "rdt"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "marcus davenport",
-    "first": "marcus",
-    "last": "davenport",
-    "position": "rde"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "mario edwards",
-    "first": "mario",
-    "last": "edwards",
-    "position": "rde"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "carl granderson",
-    "first": "carl",
-    "last": "granderson",
-    "position": "rde"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "porter gustin",
-    "first": "porter",
-    "last": "gustin",
-    "position": "rde"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "wes horton",
-    "first": "wes",
-    "last": "horton",
-    "position": "rde"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "alex anzalone",
-    "first": "alex",
-    "last": "anzalone",
-    "position": "mlb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "kaden elliss",
-    "first": "kaden",
-    "last": "elliss",
-    "position": "mlb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "a.j. klein",
-    "first": "a.j.",
-    "last": "klein",
-    "position": "slb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "vince biegel",
-    "first": "vince",
-    "last": "biegel",
-    "position": "slb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "colton jumper",
-    "first": "colton",
-    "last": "jumper",
-    "position": "slb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "demario davis",
-    "first": "demario",
-    "last": "davis",
-    "position": "wlb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "craig robertson",
-    "first": "craig",
-    "last": "robertson",
-    "position": "wlb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "darnell sankey",
-    "first": "darnell",
-    "last": "sankey",
-    "position": "wlb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "marshon lattimore",
-    "first": "marshon",
-    "last": "lattimore",
-    "position": "rcb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "ken crawley",
-    "first": "ken",
-    "last": "crawley",
-    "position": "rcb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "marcus sherels",
-    "first": "marcus",
-    "last": "sherels",
-    "position": "rcb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "chris campbell",
-    "first": "chris",
-    "last": "campbell",
-    "position": "rcb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "eli apple",
-    "first": "eli",
-    "last": "apple",
-    "position": "lcb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "patrick robinson",
-    "first": "patrick",
-    "last": "robinson",
-    "position": "lcb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "p.j. williams",
-    "first": "p.j.",
-    "last": "williams",
-    "position": "lcb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "justin hardee",
-    "first": "justin",
-    "last": "hardee",
-    "position": "lcb"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "vonn bell",
-    "first": "vonn",
-    "last": "bell",
-    "position": "ss"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "chauncey gardner-johnson",
-    "first": "chauncey",
-    "last": "gardner-johnson",
-    "position": "ss"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "saquan hampton",
-    "first": "saquan",
-    "last": "hampton",
-    "position": "ss"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "terrell williams",
-    "first": "terrell",
-    "last": "williams",
-    "position": "ss"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "marcus williams",
-    "first": "marcus",
-    "last": "williams",
-    "position": "fs"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "chris banjo",
-    "first": "chris",
-    "last": "banjo",
-    "position": "fs"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "j.t. gray",
-    "first": "j.t.",
-    "last": "gray",
-    "position": "fs"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "thomas morstead",
-    "first": "thomas",
-    "last": "morstead",
-    "position": "p"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "zach wood",
-    "first": "zach",
-    "last": "wood",
-    "position": "ls"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "nick moore",
-    "first": "nick",
-    "last": "moore",
-    "position": "ls"
-  },
-  {
-    "team": "new orleans saints",
-    "symbol": "NO",
-    "fullname": "thomas morstead",
-    "first": "thomas",
-    "last": "morstead",
-    "position": "h"
   },
   {
     "team": "new orleans saints",
@@ -10421,62 +3565,126 @@
     "fullname": "taysom hill",
     "first": "taysom",
     "last": "hill",
-    "position": "h"
+    "position": "qb"
   },
   {
     "team": "new orleans saints",
     "symbol": "NO",
-    "fullname": "wil lutz",
-    "first": "wil",
-    "last": "lutz",
-    "position": "k"
+    "fullname": "lil'jordan humphrey",
+    "first": "lil'jordan",
+    "last": "humphrey",
+    "position": "wr"
   },
   {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "nick foles",
-    "first": "nick",
-    "last": "foles",
-    "position": "qb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "tanner lee",
-    "first": "tanner",
-    "last": "lee",
-    "position": "qb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "gardner minshew",
-    "first": "gardner",
-    "last": "minshew",
-    "position": "qb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "alex mcgough",
-    "first": "alex",
-    "last": "mcgough",
-    "position": "qb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "leonard fournette",
-    "first": "leonard",
-    "last": "fournette",
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "alvin kamara",
+    "first": "alvin",
+    "last": "kamara",
     "position": "rb"
   },
   {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "alfred blue",
-    "first": "alfred",
-    "last": "blue",
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "keith kirkwood",
+    "first": "keith",
+    "last": "kirkwood",
+    "position": "wr"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "zach line",
+    "first": "zach",
+    "last": "line",
+    "position": "fb"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "alize` mack",
+    "first": "alize`",
+    "last": "mack",
+    "position": "te"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "rishard matthews",
+    "first": "rishard",
+    "last": "matthews",
+    "position": "wr"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "latavius murray",
+    "first": "latavius",
+    "last": "murray",
+    "position": "rb"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "devine ozigbo",
+    "first": "devine",
+    "last": "ozigbo",
+    "position": "rb"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "jake powell",
+    "first": "jake",
+    "last": "powell",
+    "position": "te"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "jacquizz rodgers",
+    "first": "jacquizz",
+    "last": "rodgers",
+    "position": "rb"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "tre'quan smith",
+    "first": "tre'quan",
+    "last": "smith",
+    "position": "wr"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "michael thomas",
+    "first": "michael",
+    "last": "thomas",
+    "position": "wr"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "dwayne washington",
+    "first": "dwayne",
+    "last": "washington",
+    "position": "rb"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "kerwynn williams",
+    "first": "kerwynn",
+    "last": "williams",
+    "position": "rb"
+  },
+  {
+    "team": "new orleans saints",
+    "symbol": "NO",
+    "fullname": "javorius allen",
+    "first": "javorius",
+    "last": "allen",
     "position": "rb"
   },
   {
@@ -10490,96 +3698,16 @@
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "benny cunningham",
-    "first": "benny",
-    "last": "cunningham",
+    "fullname": "alfred blue",
+    "first": "alfred",
+    "last": "blue",
     "position": "rb"
   },
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "thomas rawls",
-    "first": "thomas",
-    "last": "rawls",
-    "position": "rb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "taj mcgowan",
-    "first": "taj",
-    "last": "mcgowan",
-    "position": "rb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "fb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "marqise lee",
-    "first": "marqise",
-    "last": "lee",
-    "position": "wr"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "dede westbrook",
-    "first": "dede",
-    "last": "westbrook",
-    "position": "wr"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "chris conley",
-    "first": "chris",
-    "last": "conley",
-    "position": "wr"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "d.j. chark",
-    "first": "d.j.",
-    "last": "chark",
-    "position": "wr"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "keelan cole",
-    "first": "keelan",
-    "last": "cole",
-    "position": "wr"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "terrelle pryor",
-    "first": "terrelle",
-    "last": "pryor",
-    "position": "wr"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "tre mcbride",
-    "first": "tre",
-    "last": "mcbride",
-    "position": "wr"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "c.j. board",
-    "first": "c.j.",
+    "fullname": "cj board",
+    "first": "cj",
     "last": "board",
     "position": "wr"
   },
@@ -10594,57 +3722,65 @@
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "marcus simms",
-    "first": "marcus",
-    "last": "simms",
+    "fullname": "dj chark",
+    "first": "dj",
+    "last": "chark",
     "position": "wr"
   },
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "raphael leonard",
-    "first": "raphael",
-    "last": "leonard",
+    "fullname": "keelan cole",
+    "first": "keelan",
+    "last": "cole",
     "position": "wr"
   },
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "michael walker",
-    "first": "michael",
-    "last": "walker",
+    "fullname": "chris conley",
+    "first": "chris",
+    "last": "conley",
     "position": "wr"
   },
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "dredrick snelson",
-    "first": "dredrick",
-    "last": "snelson",
-    "position": "wr"
+    "fullname": "benny cunningham",
+    "first": "benny",
+    "last": "cunningham",
+    "position": "rb"
   },
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "geoff swaim",
-    "first": "geoff",
-    "last": "swaim",
+    "fullname": "donnie ernsberger",
+    "first": "donnie",
+    "last": "ernsberger",
     "position": "te"
   },
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "josh oliver",
-    "first": "josh",
-    "last": "oliver",
-    "position": "te"
+    "fullname": "nick foles",
+    "first": "nick",
+    "last": "foles",
+    "position": "qb"
   },
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "james o'shaughnessy",
-    "first": "james",
-    "last": "o'shaughnessy",
+    "fullname": "leonard fournette",
+    "first": "leonard",
+    "last": "fournette",
+    "position": "rb"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "charles jones ii",
+    "first": "charles",
+    "last": "jones ii",
     "position": "te"
   },
   {
@@ -10658,10 +3794,138 @@
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "charles jones",
-    "first": "charles",
-    "last": "jones",
+    "fullname": "josh lambo",
+    "first": "josh",
+    "last": "lambo",
+    "position": "k"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "marqise lee",
+    "first": "marqise",
+    "last": "lee",
+    "position": "wr"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "tanner lee",
+    "first": "tanner",
+    "last": "lee",
+    "position": "qb"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "raphael leonard",
+    "first": "raphael",
+    "last": "leonard",
+    "position": "wr"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "devante mays",
+    "first": "devante",
+    "last": "mays",
+    "position": "rb"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "tre mcbride",
+    "first": "tre",
+    "last": "mcbride",
+    "position": "wr"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "alex mcgough",
+    "first": "alex",
+    "last": "mcgough",
+    "position": "qb"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "gardner minshew ii",
+    "first": "gardner",
+    "last": "minshew ii",
+    "position": "qb"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "james o'shaughnessy",
+    "first": "james",
+    "last": "o'shaughnessy",
     "position": "te"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "josh oliver",
+    "first": "josh",
+    "last": "oliver",
+    "position": "te"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "terrelle pryor",
+    "first": "terrelle",
+    "last": "pryor",
+    "position": "wr"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "thomas rawls",
+    "first": "thomas",
+    "last": "rawls",
+    "position": "rb"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "marcus simms",
+    "first": "marcus",
+    "last": "simms",
+    "position": "wr"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "geoff swaim",
+    "first": "geoff",
+    "last": "swaim",
+    "position": "te"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "roc thomas",
+    "first": "roc",
+    "last": "thomas",
+    "position": "rb"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "michael walker",
+    "first": "michael",
+    "last": "walker",
+    "position": "wr"
+  },
+  {
+    "team": "jacksonville jaguars",
+    "symbol": "JAX",
+    "fullname": "dede westbrook",
+    "first": "dede",
+    "last": "westbrook",
+    "position": "wr"
   },
   {
     "team": "jacksonville jaguars",
@@ -10674,522 +3938,170 @@
   {
     "team": "jacksonville jaguars",
     "symbol": "JAX",
-    "fullname": "cam robinson",
-    "first": "cam",
-    "last": "robinson",
-    "position": "lt"
+    "fullname": "taj mcgowan",
+    "first": "taj",
+    "last": "mcgowan",
+    "position": "rb"
   },
   {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "josh wells",
-    "first": "josh",
-    "last": "wells",
-    "position": "lt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "andrew lauderdale",
-    "first": "andrew",
-    "last": "lauderdale",
-    "position": "lt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "donnell greene",
-    "first": "donnell",
-    "last": "greene",
-    "position": "lt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "andrew norwell",
-    "first": "andrew",
-    "last": "norwell",
-    "position": "lg"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "brandon thomas",
-    "first": "brandon",
-    "last": "thomas",
-    "position": "lg"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "kc mcdermott",
-    "first": "kc",
-    "last": "mcdermott",
-    "position": "lg"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "brandon linder",
-    "first": "brandon",
-    "last": "linder",
-    "position": "c"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "bunchy stallings",
-    "first": "bunchy",
-    "last": "stallings",
-    "position": "c"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "bunchy stallings",
-    "first": "bunchy",
-    "last": "stallings",
-    "position": "c"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "a.j. cann",
-    "first": "a.j.",
-    "last": "cann",
-    "position": "rg"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "tyler shatley",
-    "first": "tyler",
-    "last": "shatley",
-    "position": "rg"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "will richardson",
-    "first": "will",
-    "last": "richardson",
-    "position": "rt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "jawaan taylor",
-    "first": "jawaan",
-    "last": "taylor",
-    "position": "rt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "cedric ogbuehi",
-    "first": "cedric",
-    "last": "ogbuehi",
-    "position": "rt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "leonard wester",
-    "first": "leonard",
-    "last": "wester",
-    "position": "rt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "abry jones",
-    "first": "abry",
-    "last": "jones",
-    "position": "ldt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "eli ankou",
-    "first": "eli",
-    "last": "ankou",
-    "position": "ldt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "datone jones",
-    "first": "datone",
-    "last": "jones",
-    "position": "ldt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "dontavius russell",
-    "first": "dontavius",
-    "last": "russell",
-    "position": "ldt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "kalani vakameilalo",
-    "first": "kalani",
-    "last": "vakameilalo",
-    "position": "ldt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "calais campbell",
-    "first": "calais",
-    "last": "campbell",
-    "position": "lde"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "lerentee mccray",
-    "first": "lerentee",
-    "last": "mccray",
-    "position": "lde"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "marcell dareus",
-    "first": "marcell",
-    "last": "dareus",
-    "position": "rdt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "taven bryan",
-    "first": "taven",
-    "last": "bryan",
-    "position": "rdt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "mike hughes",
-    "first": "mike",
-    "last": "hughes",
-    "position": "rdt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "andrew williams",
-    "first": "andrew",
-    "last": "williams",
-    "position": "rdt"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "yannick ngakoue",
-    "first": "yannick",
-    "last": "ngakoue",
-    "position": "rde"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "josh allen",
-    "first": "josh",
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "keenan allen",
+    "first": "keenan",
     "last": "allen",
-    "position": "rde"
+    "position": "wr"
   },
   {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "dawuane smoot",
-    "first": "dawuane",
-    "last": "smoot",
-    "position": "rde"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "myles jack",
-    "first": "myles",
-    "last": "jack",
-    "position": "mlb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "najee goode",
-    "first": "najee",
-    "last": "goode",
-    "position": "mlb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "joe giles-harris",
-    "first": "joe",
-    "last": "giles-harris",
-    "position": "mlb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "leon jacobs",
-    "first": "leon",
-    "last": "jacobs",
-    "position": "slb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "ramik wilson",
-    "first": "ramik",
-    "last": "wilson",
-    "position": "slb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "connor strachan",
-    "first": "connor",
-    "last": "strachan",
-    "position": "slb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "james onwualu",
-    "first": "james",
-    "last": "onwualu",
-    "position": "slb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "jake ryan",
-    "first": "jake",
-    "last": "ryan",
-    "position": "wlb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "quincy williams",
-    "first": "quincy",
-    "last": "williams",
-    "position": "wlb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "d.j. alexander",
-    "first": "d.j.",
-    "last": "alexander",
-    "position": "wlb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "telvin smith",
-    "first": "telvin",
-    "last": "smith",
-    "position": "wlb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "a.j. bouye",
-    "first": "a.j.",
-    "last": "bouye",
-    "position": "rcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "quenton meeks",
-    "first": "quenton",
-    "last": "meeks",
-    "position": "rcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "breon borders",
-    "first": "breon",
-    "last": "borders",
-    "position": "rcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "saivion smith",
-    "first": "saivion",
-    "last": "smith",
-    "position": "rcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "brandon watson",
-    "first": "brandon",
-    "last": "watson",
-    "position": "rcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "jalen ramsey",
-    "first": "jalen",
-    "last": "ramsey",
-    "position": "lcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "d.j. hayden",
-    "first": "d.j.",
-    "last": "hayden",
-    "position": "lcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "tre herndon",
-    "first": "tre",
-    "last": "herndon",
-    "position": "lcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "tae hayes",
-    "first": "tae",
-    "last": "hayes",
-    "position": "lcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "picasso nelson",
-    "first": "picasso",
-    "last": "nelson",
-    "position": "lcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "jocquez kalili",
-    "first": "jocquez",
-    "last": "kalili",
-    "position": "lcb"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "jarrod wilson",
-    "first": "jarrod",
-    "last": "wilson",
-    "position": "ss"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "c.j. reavis",
-    "first": "c.j.",
-    "last": "reavis",
-    "position": "ss"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "joshua moon",
-    "first": "joshua",
-    "last": "moon",
-    "position": "ss"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "cody brown",
-    "first": "cody",
-    "last": "brown",
-    "position": "ss"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "ronnie harrison",
-    "first": "ronnie",
-    "last": "harrison",
-    "position": "fs"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "cody davis",
-    "first": "cody",
-    "last": "davis",
-    "position": "fs"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "andrew wingard",
-    "first": "andrew",
-    "last": "wingard",
-    "position": "fs"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "zedrick woods",
-    "first": "zedrick",
-    "last": "woods",
-    "position": "fs"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "logan cooke",
-    "first": "logan",
-    "last": "cooke",
-    "position": "p"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "matt overton",
-    "first": "matt",
-    "last": "overton",
-    "position": "ls"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "logan cooke",
-    "first": "logan",
-    "last": "cooke",
-    "position": "h"
-  },
-  {
-    "team": "jacksonville jaguars",
-    "symbol": "JAX",
-    "fullname": "josh lambo",
-    "first": "josh",
-    "last": "lambo",
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "michael badgley",
+    "first": "michael",
+    "last": "badgley",
     "position": "k"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "travis benjamin",
+    "first": "travis",
+    "last": "benjamin",
+    "position": "wr"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "jeremy cox",
+    "first": "jeremy",
+    "last": "cox",
+    "position": "rb"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "sean culkin",
+    "first": "sean",
+    "last": "culkin",
+    "position": "te"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "geremy davis",
+    "first": "geremy",
+    "last": "davis",
+    "position": "wr"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "malachi dupre",
+    "first": "malachi",
+    "last": "dupre",
+    "position": "wr"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "austin ekeler",
+    "first": "austin",
+    "last": "ekeler",
+    "position": "rb"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "derrick gore",
+    "first": "derrick",
+    "last": "gore",
+    "position": "rb"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "virgil green",
+    "first": "virgil",
+    "last": "green",
+    "position": "te"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "hunter henry",
+    "first": "hunter",
+    "last": "henry",
+    "position": "te"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "justin jackson",
+    "first": "justin",
+    "last": "jackson",
+    "position": "rb"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "cardale jones",
+    "first": "cardale",
+    "last": "jones",
+    "position": "qb"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "justice liggins",
+    "first": "justice",
+    "last": "liggins",
+    "position": "wr"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "ty long",
+    "first": "ty",
+    "last": "long",
+    "position": "k"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "vince mayle",
+    "first": "vince",
+    "last": "mayle",
+    "position": "te"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "jason moore",
+    "first": "jason",
+    "last": "moore",
+    "position": "wr"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "detrez newsome",
+    "first": "detrez",
+    "last": "newsome",
+    "position": "rb"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "andre patton",
+    "first": "andre",
+    "last": "patton",
+    "position": "wr"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "troymaine pope",
+    "first": "troymaine",
+    "last": "pope",
+    "position": "rb"
   },
   {
     "team": "los angeles chargers",
@@ -11197,6 +4109,38 @@
     "fullname": "philip rivers",
     "first": "philip",
     "last": "rivers",
+    "position": "qb"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "artavis scott",
+    "first": "artavis",
+    "last": "scott",
+    "position": "wr"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "jordan smallwood",
+    "first": "jordan",
+    "last": "smallwood",
+    "position": "wr"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "matt sokol",
+    "first": "matt",
+    "last": "sokol",
+    "position": "te"
+  },
+  {
+    "team": "los angeles chargers",
+    "symbol": "LAC",
+    "fullname": "easton stick",
+    "first": "easton",
+    "last": "stick",
     "position": "qb"
   },
   {
@@ -11210,66 +4154,10 @@
   {
     "team": "los angeles chargers",
     "symbol": "LAC",
-    "fullname": "cardale jones",
-    "first": "cardale",
-    "last": "jones",
-    "position": "qb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "easton stick",
-    "first": "easton",
-    "last": "stick",
-    "position": "qb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "melvin gordon",
-    "first": "melvin",
-    "last": "gordon",
-    "position": "rb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "austin ekeler",
-    "first": "austin",
-    "last": "ekeler",
-    "position": "rb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "justin jackson",
-    "first": "justin",
-    "last": "jackson",
-    "position": "rb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "detrez newsome",
-    "first": "detrez",
-    "last": "newsome",
-    "position": "rb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "troymaine pope",
-    "first": "troymaine",
-    "last": "pope",
-    "position": "rb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "jeremy cox",
-    "first": "jeremy",
-    "last": "cox",
-    "position": "rb"
+    "fullname": "andrew vollert",
+    "first": "andrew",
+    "last": "vollert",
+    "position": "te"
   },
   {
     "team": "los angeles chargers",
@@ -11282,25 +4170,9 @@
   {
     "team": "los angeles chargers",
     "symbol": "LAC",
-    "fullname": "keenan allen",
-    "first": "keenan",
-    "last": "allen",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
     "fullname": "mike williams",
     "first": "mike",
     "last": "williams",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "travis benjamin",
-    "first": "travis",
-    "last": "benjamin",
     "position": "wr"
   },
   {
@@ -11314,618 +4186,26 @@
   {
     "team": "los angeles chargers",
     "symbol": "LAC",
-    "fullname": "artavis scott",
-    "first": "artavis",
-    "last": "scott",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "geremy davis",
-    "first": "geremy",
-    "last": "davis",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "justice liggins",
-    "first": "justice",
-    "last": "liggins",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "jason moore",
-    "first": "jason",
-    "last": "moore",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "fred trevillion",
-    "first": "fred",
-    "last": "trevillion",
-    "position": "wr"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "hunter henry",
-    "first": "hunter",
-    "last": "henry",
-    "position": "te"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "virgil green",
-    "first": "virgil",
-    "last": "green",
-    "position": "te"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "sean culkin",
-    "first": "sean",
-    "last": "culkin",
-    "position": "te"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "vince mayle",
-    "first": "vince",
-    "last": "mayle",
-    "position": "te"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "daniel helm",
-    "first": "daniel",
-    "last": "helm",
-    "position": "te"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "matt sokol",
-    "first": "matt",
-    "last": "sokol",
-    "position": "te"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "andrew vollert",
-    "first": "andrew",
-    "last": "vollert",
-    "position": "te"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "russell okung",
-    "first": "russell",
-    "last": "okung",
-    "position": "lt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "blake camper",
-    "first": "blake",
-    "last": "camper",
-    "position": "lt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "dan feeney",
-    "first": "dan",
-    "last": "feeney",
-    "position": "lg"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "spencer drango",
-    "first": "spencer",
-    "last": "drango",
-    "position": "lg"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "mike pouncey",
-    "first": "mike",
-    "last": "pouncey",
-    "position": "c"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "scott quessenberry",
-    "first": "scott",
-    "last": "quessenberry",
-    "position": "c"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "tanner volson",
-    "first": "tanner",
-    "last": "volson",
-    "position": "c"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "michael schofield",
-    "first": "michael",
-    "last": "schofield",
-    "position": "rg"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "forrest lamp",
-    "first": "forrest",
-    "last": "lamp",
-    "position": "rg"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "sam tevi",
-    "first": "sam",
-    "last": "tevi",
-    "position": "rt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "trey pipkins",
-    "first": "trey",
-    "last": "pipkins",
-    "position": "rt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "jerry tillery",
-    "first": "jerry",
-    "last": "tillery",
-    "position": "ldt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "justin jones",
-    "first": "justin",
-    "last": "jones",
-    "position": "ldt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "cortez broughton",
-    "first": "cortez",
-    "last": "broughton",
-    "position": "ldt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "reggie howard",
-    "first": "reggie",
-    "last": "howard",
-    "position": "ldt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "joey bosa",
-    "first": "joey",
-    "last": "bosa",
-    "position": "lde"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "isaac rochell",
-    "first": "isaac",
-    "last": "rochell",
-    "position": "lde"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "damion square",
-    "first": "damion",
-    "last": "square",
-    "position": "lde"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "brandon mebane",
-    "first": "brandon",
-    "last": "mebane",
-    "position": "rdt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "t.y. mcgill",
-    "first": "t.y.",
-    "last": "mcgill",
-    "position": "rdt"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "melvin ingram",
+    "fullname": "melvin gordon",
     "first": "melvin",
-    "last": "ingram",
-    "position": "rde"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "anthony lanier",
-    "first": "anthony",
-    "last": "lanier",
-    "position": "rde"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "emeke egbule",
-    "first": "emeke",
-    "last": "egbule",
-    "position": "rde"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "josh corcoran",
-    "first": "josh",
-    "last": "corcoran",
-    "position": "rde"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "chris peace",
-    "first": "chris",
-    "last": "peace",
-    "position": "rde"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "denzel perryman",
-    "first": "denzel",
-    "last": "perryman",
-    "position": "mlb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "nick dzubnar",
-    "first": "nick",
-    "last": "dzubnar",
-    "position": "mlb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "elijah zeise",
-    "first": "elijah",
-    "last": "zeise",
-    "position": "mlb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "thomas davis",
-    "first": "thomas",
-    "last": "davis",
-    "position": "slb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "uchenna nwosu",
-    "first": "uchenna",
-    "last": "nwosu",
-    "position": "slb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "tre'von johnson",
-    "first": "tre'von",
-    "last": "johnson",
-    "position": "slb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "jatavis brown",
-    "first": "jatavis",
-    "last": "brown",
-    "position": "wlb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "kyzir white",
-    "first": "kyzir",
-    "last": "white",
-    "position": "wlb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "drue tranquill",
-    "first": "drue",
-    "last": "tranquill",
-    "position": "wlb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "kyle wilson",
-    "first": "kyle",
-    "last": "wilson",
-    "position": "wlb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "casey hayward",
-    "first": "casey",
-    "last": "hayward",
-    "position": "rcb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "desmond king",
-    "first": "desmond",
-    "last": "king",
-    "position": "rcb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "jeff richards",
-    "first": "jeff",
-    "last": "richards",
-    "position": "rcb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "arrion springs",
-    "first": "arrion",
-    "last": "springs",
-    "position": "rcb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "rodney randle",
-    "first": "rodney",
-    "last": "randle",
-    "position": "rcb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "trevor williams",
-    "first": "trevor",
-    "last": "williams",
-    "position": "lcb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "michael davis",
-    "first": "michael",
-    "last": "davis",
-    "position": "lcb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "brandon facyson",
-    "first": "brandon",
-    "last": "facyson",
-    "position": "lcb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "bradford lemmons",
-    "first": "bradford",
-    "last": "lemmons",
-    "position": "lcb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "kemon hall",
-    "first": "kemon",
-    "last": "hall",
-    "position": "lcb"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "derwin james",
-    "first": "derwin",
-    "last": "james",
-    "position": "ss"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "adrian phillips",
-    "first": "adrian",
-    "last": "phillips",
-    "position": "ss"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "rayshawn jenkins",
-    "first": "rayshawn",
-    "last": "jenkins",
-    "position": "fs"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "nasir adderley",
-    "first": "nasir",
-    "last": "adderley",
-    "position": "fs"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "jaylen watkins",
-    "first": "jaylen",
-    "last": "watkins",
-    "position": "fs"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "roderic teamer",
-    "first": "roderic",
-    "last": "teamer",
-    "position": "fs"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "adarius pickett",
-    "first": "adarius",
-    "last": "pickett",
-    "position": "fs"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "ty long",
-    "first": "ty",
-    "last": "long",
-    "position": "p"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "mike windt",
-    "first": "mike",
-    "last": "windt",
-    "position": "ls"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "cole mazza",
-    "first": "cole",
-    "last": "mazza",
-    "position": "ls"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "ty long",
-    "first": "ty",
-    "last": "long",
-    "position": "h"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "tyrod taylor",
-    "first": "tyrod",
-    "last": "taylor",
-    "position": "h"
-  },
-  {
-    "team": "los angeles chargers",
-    "symbol": "LAC",
-    "fullname": "mike badgley",
-    "first": "mike",
-    "last": "badgley",
-    "position": "k"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "joe flacco",
-    "first": "joe",
-    "last": "flacco",
-    "position": "qb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "drew lock",
-    "first": "drew",
-    "last": "lock",
-    "position": "qb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "kevin hogan",
-    "first": "kevin",
-    "last": "hogan",
-    "position": "qb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "brett rypien",
-    "first": "brett",
-    "last": "rypien",
-    "position": "qb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "phillip lindsay",
-    "first": "phillip",
-    "last": "lindsay",
+    "last": "gordon",
     "position": "rb"
   },
   {
     "team": "denver broncos",
     "symbol": "DEN",
-    "fullname": "royce freeman",
-    "first": "royce",
-    "last": "freeman",
-    "position": "rb"
+    "fullname": "george aston",
+    "first": "george",
+    "last": "aston",
+    "position": "fb"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "trinity benson",
+    "first": "trinity",
+    "last": "benson",
+    "position": "wr"
   },
   {
     "team": "denver broncos",
@@ -11938,10 +4218,106 @@
   {
     "team": "denver broncos",
     "symbol": "DEN",
-    "fullname": "khalfani muhammad",
-    "first": "khalfani",
-    "last": "muhammad",
+    "fullname": "fred brown",
+    "first": "fred",
+    "last": "brown",
+    "position": "wr"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "jake butt",
+    "first": "jake",
+    "last": "butt",
+    "position": "te"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "river cracraft",
+    "first": "river",
+    "last": "cracraft",
+    "position": "wr"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "steven dunbar",
+    "first": "steven",
+    "last": "dunbar",
+    "position": "wr"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "noah fant",
+    "first": "noah",
+    "last": "fant",
+    "position": "te"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "joe flacco",
+    "first": "joe",
+    "last": "flacco",
+    "position": "qb"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "austin fort",
+    "first": "austin",
+    "last": "fort",
+    "position": "te"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "royce freeman",
+    "first": "royce",
+    "last": "freeman",
     "position": "rb"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "troy fumagalli",
+    "first": "troy",
+    "last": "fumagalli",
+    "position": "te"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "daesean hamilton",
+    "first": "daesean",
+    "last": "hamilton",
+    "position": "wr"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "jeff heuerman",
+    "first": "jeff",
+    "last": "heuerman",
+    "position": "te"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "kevin hogan",
+    "first": "kevin",
+    "last": "hogan",
+    "position": "qb"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "bug howard",
+    "first": "bug",
+    "last": "howard",
+    "position": "wr"
   },
   {
     "team": "denver broncos",
@@ -11962,82 +4338,18 @@
   {
     "team": "denver broncos",
     "symbol": "DEN",
-    "fullname": "george aston",
-    "first": "george",
-    "last": "aston",
-    "position": "fb"
+    "fullname": "phillip lindsay",
+    "first": "phillip",
+    "last": "lindsay",
+    "position": "rb"
   },
   {
     "team": "denver broncos",
     "symbol": "DEN",
-    "fullname": "emmanuel sanders",
-    "first": "emmanuel",
-    "last": "sanders",
-    "position": "wr"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "courtland sutton",
-    "first": "courtland",
-    "last": "sutton",
-    "position": "wr"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "daesean hamilton",
-    "first": "daesean",
-    "last": "hamilton",
-    "position": "wr"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "tim patrick",
-    "first": "tim",
-    "last": "patrick",
-    "position": "wr"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "juwann winfree",
-    "first": "juwann",
-    "last": "winfree",
-    "position": "wr"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "river cracraft",
-    "first": "river",
-    "last": "cracraft",
-    "position": "wr"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "aaron burbridge",
-    "first": "aaron",
-    "last": "burbridge",
-    "position": "wr"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "brendan langley",
-    "first": "brendan",
-    "last": "langley",
-    "position": "wr"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "trinity benson",
-    "first": "trinity",
-    "last": "benson",
-    "position": "wr"
+    "fullname": "drew lock",
+    "first": "drew",
+    "last": "lock",
+    "position": "qb"
   },
   {
     "team": "denver broncos",
@@ -12050,454 +4362,6 @@
   {
     "team": "denver broncos",
     "symbol": "DEN",
-    "fullname": "romell guerrier",
-    "first": "romell",
-    "last": "guerrier",
-    "position": "wr"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "bug howard",
-    "first": "bug",
-    "last": "howard",
-    "position": "wr"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "jeff heuerman",
-    "first": "jeff",
-    "last": "heuerman",
-    "position": "te"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "noah fant",
-    "first": "noah",
-    "last": "fant",
-    "position": "te"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "jake butt",
-    "first": "jake",
-    "last": "butt",
-    "position": "te"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "troy fumagalli",
-    "first": "troy",
-    "last": "fumagalli",
-    "position": "te"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "austin fort",
-    "first": "austin",
-    "last": "fort",
-    "position": "te"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "garett bolles",
-    "first": "garett",
-    "last": "bolles",
-    "position": "lt"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "jake rodgers",
-    "first": "jake",
-    "last": "rodgers",
-    "position": "lt"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "ronald leary",
-    "first": "ronald",
-    "last": "leary",
-    "position": "lg"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "chaz green",
-    "first": "chaz",
-    "last": "green",
-    "position": "lg"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "connor mcgovern",
-    "first": "connor",
-    "last": "mcgovern",
-    "position": "c"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "sam jones",
-    "first": "sam",
-    "last": "jones",
-    "position": "c"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "jake brendel",
-    "first": "jake",
-    "last": "brendel",
-    "position": "c"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "dalton risner",
-    "first": "dalton",
-    "last": "risner",
-    "position": "rg"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "elijah wilkinson",
-    "first": "elijah",
-    "last": "wilkinson",
-    "position": "rg"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "don barclay",
-    "first": "don",
-    "last": "barclay",
-    "position": "rg"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "ja'wuan james",
-    "first": "ja'wuan",
-    "last": "james",
-    "position": "rt"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "derek wolfe",
-    "first": "derek",
-    "last": "wolfe",
-    "position": "lde"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "zach kerr",
-    "first": "zach",
-    "last": "kerr",
-    "position": "lde"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "ahmad gooden",
-    "first": "ahmad",
-    "last": "gooden",
-    "position": "lde"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "deyon sizer",
-    "first": "deyon",
-    "last": "sizer",
-    "position": "lde"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "shelby harris",
-    "first": "shelby",
-    "last": "harris",
-    "position": "ndt"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "dre'mont jones",
-    "first": "dre'mont",
-    "last": "jones",
-    "position": "ndt"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "mike purcell",
-    "first": "mike",
-    "last": "purcell",
-    "position": "ndt"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "deshawn williams",
-    "first": "deshawn",
-    "last": "williams",
-    "position": "ndt"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "adam gotsis",
-    "first": "adam",
-    "last": "gotsis",
-    "position": "rde"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "demarcus walker",
-    "first": "demarcus",
-    "last": "walker",
-    "position": "rde"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "billy winn",
-    "first": "billy",
-    "last": "winn",
-    "position": "rde"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "bradley chubb",
-    "first": "bradley",
-    "last": "chubb",
-    "position": "slb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "justin hollins",
-    "first": "justin",
-    "last": "hollins",
-    "position": "slb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "jeff holland",
-    "first": "jeff",
-    "last": "holland",
-    "position": "slb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "von miller",
-    "first": "von",
-    "last": "miller",
-    "position": "wlb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "aaron wallace",
-    "first": "aaron",
-    "last": "wallace",
-    "position": "wlb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "isaac yiadom",
-    "first": "isaac",
-    "last": "yiadom",
-    "position": "rcb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "devante bausby",
-    "first": "devante",
-    "last": "bausby",
-    "position": "rcb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "trey johnson",
-    "first": "trey",
-    "last": "johnson",
-    "position": "rcb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "chris harris",
-    "first": "chris",
-    "last": "harris",
-    "position": "lcb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "bryce callahan",
-    "first": "bryce",
-    "last": "callahan",
-    "position": "lcb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "horace richardson",
-    "first": "horace",
-    "last": "richardson",
-    "position": "lcb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "linden stephens",
-    "first": "linden",
-    "last": "stephens",
-    "position": "lcb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "alijah holder",
-    "first": "alijah",
-    "last": "holder",
-    "position": "lcb"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "justin simmons",
-    "first": "justin",
-    "last": "simmons",
-    "position": "ss"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "su'a cravens",
-    "first": "su'a",
-    "last": "cravens",
-    "position": "ss"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "trey marshall",
-    "first": "trey",
-    "last": "marshall",
-    "position": "ss"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "jamal carter",
-    "first": "jamal",
-    "last": "carter",
-    "position": "ss"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "kareem jackson",
-    "first": "kareem",
-    "last": "jackson",
-    "position": "fs"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "will parks",
-    "first": "will",
-    "last": "parks",
-    "position": "fs"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "shamarko thomas",
-    "first": "shamarko",
-    "last": "thomas",
-    "position": "fs"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "dymonte thomas",
-    "first": "dymonte",
-    "last": "thomas",
-    "position": "fs"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "colby wadman",
-    "first": "colby",
-    "last": "wadman",
-    "position": "p"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "casey kreiter",
-    "first": "casey",
-    "last": "kreiter",
-    "position": "ls"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
-    "fullname": "colby wadman",
-    "first": "colby",
-    "last": "wadman",
-    "position": "h"
-  },
-  {
-    "team": "denver broncos",
-    "symbol": "DEN",
     "fullname": "brandon mcmanus",
     "first": "brandon",
     "last": "mcmanus",
@@ -12506,10 +4370,138 @@
   {
     "team": "denver broncos",
     "symbol": "DEN",
-    "fullname": "taylor bertolet",
-    "first": "taylor",
-    "last": "bertolet",
-    "position": "k"
+    "fullname": "khalfani muhammad",
+    "first": "khalfani",
+    "last": "muhammad",
+    "position": "rb"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "tim patrick",
+    "first": "tim",
+    "last": "patrick",
+    "position": "wr"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "theo riddick",
+    "first": "theo",
+    "last": "riddick",
+    "position": "rb"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "brett rypien",
+    "first": "brett",
+    "last": "rypien",
+    "position": "qb"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "emmanuel sanders",
+    "first": "emmanuel",
+    "last": "sanders",
+    "position": "wr"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "moral stephens",
+    "first": "moral",
+    "last": "stephens",
+    "position": "te"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "courtland sutton",
+    "first": "courtland",
+    "last": "sutton",
+    "position": "wr"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "david williams",
+    "first": "david",
+    "last": "williams",
+    "position": "rb"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "nick williams",
+    "first": "nick",
+    "last": "williams",
+    "position": "wr"
+  },
+  {
+    "team": "denver broncos",
+    "symbol": "DEN",
+    "fullname": "juwann winfree",
+    "first": "juwann",
+    "last": "winfree",
+    "position": "wr"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "dwayne allen",
+    "first": "dwayne",
+    "last": "allen",
+    "position": "te"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "kalen ballage",
+    "first": "kalen",
+    "last": "ballage",
+    "position": "rb"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "saeed blacknall",
+    "first": "saeed",
+    "last": "blacknall",
+    "position": "wr"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "brice butler",
+    "first": "brice",
+    "last": "butler",
+    "position": "wr"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "chandler cox",
+    "first": "chandler",
+    "last": "cox",
+    "position": "fb"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "kenyan drake",
+    "first": "kenyan",
+    "last": "drake",
+    "position": "rb"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "kenneth farrow",
+    "first": "kenneth",
+    "last": "farrow",
+    "position": "rb"
   },
   {
     "team": "miami dolphins",
@@ -12518,6 +4510,94 @@
     "first": "ryan",
     "last": "fitzpatrick",
     "position": "qb"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "isaiah ford",
+    "first": "isaiah",
+    "last": "ford",
+    "position": "wr"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "myles gaskin",
+    "first": "myles",
+    "last": "gaskin",
+    "position": "rb"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "mike gesicki",
+    "first": "mike",
+    "last": "gesicki",
+    "position": "te"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "jakeem grant",
+    "first": "jakeem",
+    "last": "grant",
+    "position": "wr"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "reece horn",
+    "first": "reece",
+    "last": "horn",
+    "position": "wr"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "allen hurns",
+    "first": "allen",
+    "last": "hurns",
+    "position": "wr"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "trenton irwin",
+    "first": "trenton",
+    "last": "irwin",
+    "position": "wr"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "patrick laird",
+    "first": "patrick",
+    "last": "laird",
+    "position": "rb"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "chris myarick",
+    "first": "chris",
+    "last": "myarick",
+    "position": "te"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "nick o'leary",
+    "first": "nick",
+    "last": "o'leary",
+    "position": "te"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "devante parker",
+    "first": "devante",
+    "last": "parker",
+    "position": "wr"
   },
   {
     "team": "miami dolphins",
@@ -12538,58 +4618,18 @@
   {
     "team": "miami dolphins",
     "symbol": "MIA",
-    "fullname": "kenyan drake",
-    "first": "kenyan",
-    "last": "drake",
-    "position": "rb"
+    "fullname": "jason sanders",
+    "first": "jason",
+    "last": "sanders",
+    "position": "k"
   },
   {
     "team": "miami dolphins",
     "symbol": "MIA",
-    "fullname": "kalen ballage",
-    "first": "kalen",
-    "last": "ballage",
-    "position": "rb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "myles gaskin",
-    "first": "myles",
-    "last": "gaskin",
-    "position": "rb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "kenneth farrow",
-    "first": "kenneth",
-    "last": "farrow",
-    "position": "rb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "mark walton",
-    "first": "mark",
-    "last": "walton",
-    "position": "rb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "patrick laird",
-    "first": "patrick",
-    "last": "laird",
-    "position": "rb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "chandler cox",
-    "first": "chandler",
-    "last": "cox",
-    "position": "fb"
+    "fullname": "durham smythe",
+    "first": "durham",
+    "last": "smythe",
+    "position": "te"
   },
   {
     "team": "miami dolphins",
@@ -12602,9 +4642,25 @@
   {
     "team": "miami dolphins",
     "symbol": "MIA",
-    "fullname": "devante parker",
-    "first": "devante",
-    "last": "parker",
+    "fullname": "clive walford",
+    "first": "clive",
+    "last": "walford",
+    "position": "te"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "mark walton",
+    "first": "mark",
+    "last": "walton",
+    "position": "rb"
+  },
+  {
+    "team": "miami dolphins",
+    "symbol": "MIA",
+    "fullname": "preston williams",
+    "first": "preston",
+    "last": "williams",
     "position": "wr"
   },
   {
@@ -12618,650 +4674,18 @@
   {
     "team": "miami dolphins",
     "symbol": "MIA",
-    "fullname": "jakeem grant",
-    "first": "jakeem",
-    "last": "grant",
-    "position": "wr"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "brice butler",
-    "first": "brice",
-    "last": "butler",
-    "position": "wr"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "preston williams",
-    "first": "preston",
-    "last": "williams",
-    "position": "wr"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "isaiah ford",
-    "first": "isaiah",
-    "last": "ford",
-    "position": "wr"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "reece horn",
-    "first": "reece",
-    "last": "horn",
-    "position": "wr"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "trenton irwin",
-    "first": "trenton",
-    "last": "irwin",
-    "position": "wr"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
     "fullname": "ricardo louis",
     "first": "ricardo",
     "last": "louis",
     "position": "wr"
   },
   {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "mike gesicki",
-    "first": "mike",
-    "last": "gesicki",
-    "position": "te"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "dwayne allen",
-    "first": "dwayne",
-    "last": "allen",
-    "position": "te"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "durham smythe",
-    "first": "durham",
-    "last": "smythe",
-    "position": "te"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "nick o'leary",
-    "first": "nick",
-    "last": "o'leary",
-    "position": "te"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "clive walford",
-    "first": "clive",
-    "last": "walford",
-    "position": "te"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "chris myarick",
-    "first": "chris",
-    "last": "myarick",
-    "position": "te"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "laremy tunsil",
-    "first": "laremy",
-    "last": "tunsil",
-    "position": "lt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jaryd jones-smith",
-    "first": "jaryd",
-    "last": "jones-smith",
-    "position": "lt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "chris reed",
-    "first": "chris",
-    "last": "reed",
-    "position": "lg"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "michael deiter",
-    "first": "michael",
-    "last": "deiter",
-    "position": "lg"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "daniel kilgore",
-    "first": "daniel",
-    "last": "kilgore",
-    "position": "c"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "ryan anderson",
-    "first": "ryan",
+    "team": "new york jets",
+    "symbol": "NYJ",
+    "fullname": "robby anderson",
+    "first": "robby",
     "last": "anderson",
-    "position": "c"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "tony adams",
-    "first": "tony",
-    "last": "adams",
-    "position": "c"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jesse davis",
-    "first": "jesse",
-    "last": "davis",
-    "position": "rg"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "kyle fuller",
-    "first": "kyle",
-    "last": "fuller",
-    "position": "rg"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "shaq calhoun",
-    "first": "shaq",
-    "last": "calhoun",
-    "position": "rg"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jordan mills",
-    "first": "jordan",
-    "last": "mills",
-    "position": "rt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "zach sterup",
-    "first": "zach",
-    "last": "sterup",
-    "position": "rt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "isaiah prince",
-    "first": "isaiah",
-    "last": "prince",
-    "position": "rt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "michael dunn",
-    "first": "michael",
-    "last": "dunn",
-    "position": "rt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "davon godchaux",
-    "first": "davon",
-    "last": "godchaux",
-    "position": "ldt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "adolphus washington",
-    "first": "adolphus",
-    "last": "washington",
-    "position": "ldt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "joey mbu",
-    "first": "joey",
-    "last": "mbu",
-    "position": "ldt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "cory thomas",
-    "first": "cory",
-    "last": "thomas",
-    "position": "ldt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jonathan woodard",
-    "first": "jonathan",
-    "last": "woodard",
-    "position": "lde"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "tank carradine",
-    "first": "tank",
-    "last": "carradine",
-    "position": "lde"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jay elliott",
-    "first": "jay",
-    "last": "elliott",
-    "position": "lde"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "nate orchard",
-    "first": "nate",
-    "last": "orchard",
-    "position": "lde"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "christian wilkins",
-    "first": "christian",
-    "last": "wilkins",
-    "position": "rdt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "akeem spence",
-    "first": "akeem",
-    "last": "spence",
-    "position": "rdt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "vincent taylor",
-    "first": "vincent",
-    "last": "taylor",
-    "position": "rdt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jamiyus pittman",
-    "first": "jamiyus",
-    "last": "pittman",
-    "position": "rdt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "durval queiroz",
-    "first": "durval",
-    "last": "queiroz",
-    "position": "rdt"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "charles harris",
-    "first": "charles",
-    "last": "harris",
-    "position": "rde"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jonathan ledbetter",
-    "first": "jonathan",
-    "last": "ledbetter",
-    "position": "rde"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "andrew van ginkel",
-    "first": "andrew",
-    "last": "van",
-    "position": "rde"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "dewayne hendrix",
-    "first": "dewayne",
-    "last": "hendrix",
-    "position": "rde"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "raekwon mcmillan",
-    "first": "raekwon",
-    "last": "mcmillan",
-    "position": "mlb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "mike hull",
-    "first": "mike",
-    "last": "hull",
-    "position": "mlb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "tre watson",
-    "first": "tre",
-    "last": "watson",
-    "position": "mlb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jerome baker",
-    "first": "jerome",
-    "last": "baker",
-    "position": "slb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "chase allen",
-    "first": "chase",
-    "last": "allen",
-    "position": "slb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "kiko alonso",
-    "first": "kiko",
-    "last": "alonso",
-    "position": "wlb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "quentin poling",
-    "first": "quentin",
-    "last": "poling",
-    "position": "wlb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "tyrone holmes",
-    "first": "tyrone",
-    "last": "holmes",
-    "position": "wlb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "terrill hanks",
-    "first": "terrill",
-    "last": "hanks",
-    "position": "wlb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "xavien howard",
-    "first": "xavien",
-    "last": "howard",
-    "position": "rcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "minkah fitzpatrick",
-    "first": "minkah",
-    "last": "fitzpatrick",
-    "position": "rcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "cornell armstrong",
-    "first": "cornell",
-    "last": "armstrong",
-    "position": "rcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "torry mctyer",
-    "first": "torry",
-    "last": "mctyer",
-    "position": "rcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "montre hartage",
-    "first": "montre",
-    "last": "hartage",
-    "position": "rcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "eric rowe",
-    "first": "eric",
-    "last": "rowe",
-    "position": "lcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "bobby mccain",
-    "first": "bobby",
-    "last": "mccain",
-    "position": "lcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "cordrea tankersley",
-    "first": "cordrea",
-    "last": "tankersley",
-    "position": "lcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jalen davis",
-    "first": "jalen",
-    "last": "davis",
-    "position": "lcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jomal wiltz",
-    "first": "jomal",
-    "last": "wiltz",
-    "position": "lcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "nik needham",
-    "first": "nik",
-    "last": "needham",
-    "position": "lcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jamar summers",
-    "first": "jamar",
-    "last": "summers",
-    "position": "lcb"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "reshad jones",
-    "first": "reshad",
-    "last": "jones",
-    "position": "ss"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "walt aikens",
-    "first": "walt",
-    "last": "aikens",
-    "position": "ss"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "maurice smith",
-    "first": "maurice",
-    "last": "smith",
-    "position": "ss"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "t.j. mcdonald",
-    "first": "t.j.",
-    "last": "mcdonald",
-    "position": "fs"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "minkah fitzpatrick",
-    "first": "minkah",
-    "last": "fitzpatrick",
-    "position": "fs"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "chris lammons",
-    "first": "chris",
-    "last": "lammons",
-    "position": "fs"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "matt haack",
-    "first": "matt",
-    "last": "haack",
-    "position": "p"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "stone wilson",
-    "first": "stone",
-    "last": "wilson",
-    "position": "p"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "john denney",
-    "first": "john",
-    "last": "denney",
-    "position": "ls"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "matt haack",
-    "first": "matt",
-    "last": "haack",
-    "position": "h"
-  },
-  {
-    "team": "miami dolphins",
-    "symbol": "MIA",
-    "fullname": "jason sanders",
-    "first": "jason",
-    "last": "sanders",
-    "position": "k"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "sam darnold",
-    "first": "sam",
-    "last": "darnold",
-    "position": "qb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "trevor siemian",
-    "first": "trevor",
-    "last": "siemian",
-    "position": "qb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "davis webb",
-    "first": "davis",
-    "last": "webb",
-    "position": "qb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "luke falk",
-    "first": "luke",
-    "last": "falk",
-    "position": "qb"
+    "position": "wr"
   },
   {
     "team": "new york jets",
@@ -13274,34 +4698,26 @@
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "bilal powell",
-    "first": "bilal",
-    "last": "powell",
-    "position": "rb"
+    "fullname": "josh bellamy",
+    "first": "josh",
+    "last": "bellamy",
+    "position": "wr"
   },
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "ty montgomery",
-    "first": "ty",
-    "last": "montgomery",
-    "position": "rb"
+    "fullname": "daniel brown",
+    "first": "daniel",
+    "last": "brown",
+    "position": "te"
   },
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "elijah mcguire",
-    "first": "elijah",
-    "last": "mcguire",
-    "position": "rb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "de'angelo henderson sr.",
-    "first": "de'angelo",
-    "last": "henderson",
-    "position": "rb"
+    "fullname": "deontay burnett",
+    "first": "deontay",
+    "last": "burnett",
+    "position": "wr"
   },
   {
     "team": "new york jets",
@@ -13314,25 +4730,33 @@
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "valentine holmes",
-    "first": "valentine",
-    "last": "holmes",
-    "position": "rb"
+    "fullname": "chandler catanzaro",
+    "first": "chandler",
+    "last": "catanzaro",
+    "position": "k"
   },
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "fb"
+    "fullname": "jamison crowder",
+    "first": "jamison",
+    "last": "crowder",
+    "position": "wr"
   },
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "robby anderson",
-    "first": "robby",
-    "last": "anderson",
+    "fullname": "sam darnold",
+    "first": "sam",
+    "last": "darnold",
+    "position": "qb"
+  },
+  {
+    "team": "new york jets",
+    "symbol": "NYJ",
+    "fullname": "greg dortch",
+    "first": "greg",
+    "last": "dortch",
     "position": "wr"
   },
   {
@@ -13346,41 +4770,57 @@
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "jamison crowder",
-    "first": "jamison",
-    "last": "crowder",
+    "fullname": "luke falk",
+    "first": "luke",
+    "last": "falk",
+    "position": "qb"
+  },
+  {
+    "team": "new york jets",
+    "symbol": "NYJ",
+    "fullname": "ryan griffin",
+    "first": "ryan",
+    "last": "griffin",
+    "position": "te"
+  },
+  {
+    "team": "new york jets",
+    "symbol": "NYJ",
+    "fullname": "christopher herndon iv",
+    "first": "christopher",
+    "last": "herndon iv",
+    "position": "te"
+  },
+  {
+    "team": "new york jets",
+    "symbol": "NYJ",
+    "fullname": "valentine holmes",
+    "first": "valentine",
+    "last": "holmes",
+    "position": "rb"
+  },
+  {
+    "team": "new york jets",
+    "symbol": "NYJ",
+    "fullname": "jj jones",
+    "first": "jj",
+    "last": "jones",
     "position": "wr"
   },
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "josh bellamy",
-    "first": "josh",
-    "last": "bellamy",
-    "position": "wr"
+    "fullname": "elijah mcguire",
+    "first": "elijah",
+    "last": "mcguire",
+    "position": "rb"
   },
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "deonte thompson",
-    "first": "deonte",
-    "last": "thompson",
-    "position": "wr"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "deontay burnett",
-    "first": "deontay",
-    "last": "burnett",
-    "position": "wr"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "greg dortch",
-    "first": "greg",
-    "last": "dortch",
+    "fullname": "ty montgomery",
+    "first": "ty",
+    "last": "montgomery",
     "position": "wr"
   },
   {
@@ -13394,26 +4834,18 @@
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "quadree henderson",
-    "first": "quadree",
-    "last": "henderson",
-    "position": "wr"
+    "fullname": "bilal powell",
+    "first": "bilal",
+    "last": "powell",
+    "position": "rb"
   },
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "tim white",
-    "first": "tim",
-    "last": "white",
-    "position": "wr"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "j.j. jones",
-    "first": "j.j.",
-    "last": "jones",
-    "position": "wr"
+    "fullname": "trevor siemian",
+    "first": "trevor",
+    "last": "siemian",
+    "position": "qb"
   },
   {
     "team": "new york jets",
@@ -13426,10 +4858,10 @@
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "chris herndon",
-    "first": "chris",
-    "last": "herndon",
-    "position": "te"
+    "fullname": "deonte thompson",
+    "first": "deonte",
+    "last": "thompson",
+    "position": "wr"
   },
   {
     "team": "new york jets",
@@ -13442,6 +4874,14 @@
   {
     "team": "new york jets",
     "symbol": "NYJ",
+    "fullname": "davis webb",
+    "first": "davis",
+    "last": "webb",
+    "position": "qb"
+  },
+  {
+    "team": "new york jets",
+    "symbol": "NYJ",
     "fullname": "trevon wesco",
     "first": "trevon",
     "last": "wesco",
@@ -13450,626 +4890,26 @@
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "daniel brown",
-    "first": "daniel",
-    "last": "brown",
+    "fullname": "tim white",
+    "first": "tim",
+    "last": "white",
+    "position": "wr"
+  },
+  {
+    "team": "new york jets",
+    "symbol": "NYJ",
+    "fullname": "bucky hodges",
+    "first": "bucky",
+    "last": "hodges",
     "position": "te"
   },
   {
     "team": "new york jets",
     "symbol": "NYJ",
-    "fullname": "kelvin beachum",
-    "first": "kelvin",
-    "last": "beachum",
-    "position": "lt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "chuma edoga",
-    "first": "chuma",
-    "last": "edoga",
-    "position": "lt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "eric smith",
-    "first": "eric",
-    "last": "smith",
-    "position": "lt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "calvin anderson",
-    "first": "calvin",
-    "last": "anderson",
-    "position": "lt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "kelechi osemele",
-    "first": "kelechi",
-    "last": "osemele",
-    "position": "lg"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "jordan morgan",
-    "first": "jordan",
-    "last": "morgan",
-    "position": "lg"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "tyler jones",
-    "first": "tyler",
-    "last": "jones",
-    "position": "lg"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "jonotthan harrison",
-    "first": "jonotthan",
-    "last": "harrison",
-    "position": "c"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "jon toth",
-    "first": "jon",
-    "last": "toth",
-    "position": "c"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "toa lobendahn",
-    "first": "toa",
-    "last": "lobendahn",
-    "position": "c"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "brian winters",
-    "first": "brian",
-    "last": "winters",
-    "position": "rg"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "tom compton",
-    "first": "tom",
-    "last": "compton",
-    "position": "rg"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "brandon shell",
-    "first": "brandon",
-    "last": "shell",
-    "position": "rt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "brent qvale",
-    "first": "brent",
-    "last": "qvale",
-    "position": "rt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "ben braden",
-    "first": "ben",
-    "last": "braden",
-    "position": "rt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "leonard williams",
-    "first": "leonard",
-    "last": "williams",
-    "position": "lde"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "foley fatukasi",
-    "first": "foley",
-    "last": "fatukasi",
-    "position": "lde"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "bronson kaufusi",
-    "first": "bronson",
-    "last": "kaufusi",
-    "position": "lde"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "kyle phillips",
-    "first": "kyle",
-    "last": "phillips",
-    "position": "lde"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "quinnen williams",
-    "first": "quinnen",
-    "last": "williams",
-    "position": "ndt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "steve mclendon",
-    "first": "steve",
-    "last": "mclendon",
-    "position": "ndt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "fred jones",
-    "first": "fred",
-    "last": "jones",
-    "position": "ndt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "trevon sanders",
-    "first": "trevon",
-    "last": "sanders",
-    "position": "ndt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "henry anderson",
-    "first": "henry",
-    "last": "anderson",
-    "position": "rde"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "nathan shepherd",
-    "first": "nathan",
-    "last": "shepherd",
-    "position": "rde"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "brandon copeland",
-    "first": "brandon",
-    "last": "copeland",
-    "position": "slb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "jachai polite",
-    "first": "jachai",
-    "last": "polite",
-    "position": "slb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "frankie luvu",
-    "first": "frankie",
-    "last": "luvu",
-    "position": "slb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "kevin pierre-louis",
-    "first": "kevin",
-    "last": "pierre-louis",
-    "position": "slb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "jordan jenkins",
-    "first": "jordan",
-    "last": "jenkins",
-    "position": "wlb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "tarell basham",
-    "first": "tarell",
-    "last": "basham",
-    "position": "wlb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "jamey mosley",
-    "first": "jamey",
-    "last": "mosley",
-    "position": "wlb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "justin alexandre",
-    "first": "justin",
-    "last": "alexandre",
-    "position": "wlb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "trumaine johnson",
-    "first": "trumaine",
-    "last": "johnson",
-    "position": "rcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "arthur maulet",
-    "first": "arthur",
-    "last": "maulet",
-    "position": "rcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "derrick jones",
-    "first": "derrick",
-    "last": "jones",
-    "position": "rcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "jeremy clark",
-    "first": "jeremy",
-    "last": "clark",
-    "position": "rcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "montrel meander",
-    "first": "montrel",
-    "last": "meander",
-    "position": "rcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "marko myers",
-    "first": "marko",
-    "last": "myers",
-    "position": "rcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "darryl roberts",
-    "first": "darryl",
-    "last": "roberts",
-    "position": "lcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "brian poole",
-    "first": "brian",
-    "last": "poole",
-    "position": "lcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "parry nickerson",
-    "first": "parry",
-    "last": "nickerson",
-    "position": "lcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "tevaughn campbell",
-    "first": "tevaughn",
-    "last": "campbell",
-    "position": "lcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "blessuan austin",
-    "first": "blessuan",
-    "last": "austin",
-    "position": "lcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "kyron brown",
-    "first": "kyron",
-    "last": "brown",
-    "position": "lcb"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "jamal adams",
-    "first": "jamal",
-    "last": "adams",
-    "position": "ss"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "brandon bryant",
-    "first": "brandon",
-    "last": "bryant",
-    "position": "ss"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "santos ramirez",
-    "first": "santos",
-    "last": "ramirez",
-    "position": "ss"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "marcus maye",
-    "first": "marcus",
-    "last": "maye",
-    "position": "fs"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "doug middleton",
-    "first": "doug",
-    "last": "middleton",
-    "position": "fs"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "rontez miles",
-    "first": "rontez",
-    "last": "miles",
-    "position": "fs"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "lac edwards",
-    "first": "lac",
-    "last": "edwards",
-    "position": "p"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "matt darr",
-    "first": "matt",
-    "last": "darr",
-    "position": "p"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "thomas hennessy",
-    "first": "thomas",
-    "last": "hennessy",
-    "position": "ls"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "lac edwards",
-    "first": "lac",
-    "last": "edwards",
-    "position": "h"
-  },
-  {
-    "team": "new york jets",
-    "symbol": "NYJ",
-    "fullname": "chandler catanzaro",
-    "first": "chandler",
-    "last": "catanzaro",
-    "position": "k"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "matt ryan",
-    "first": "matt",
-    "last": "ryan",
-    "position": "qb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "matt schaub",
-    "first": "matt",
-    "last": "schaub",
-    "position": "qb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "kurt benkert",
-    "first": "kurt",
-    "last": "benkert",
-    "position": "qb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "devonta freeman",
-    "first": "devonta",
-    "last": "freeman",
+    "fullname": "jalin moore",
+    "first": "jalin",
+    "last": "moore",
     "position": "rb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "ito smith",
-    "first": "ito",
-    "last": "smith",
-    "position": "rb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "qadree ollison",
-    "first": "qadree",
-    "last": "ollison",
-    "position": "rb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "brian hill",
-    "first": "brian",
-    "last": "hill",
-    "position": "rb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "kenjon barner",
-    "first": "kenjon",
-    "last": "barner",
-    "position": "rb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "tony brooks-james",
-    "first": "tony",
-    "last": "brooks-james",
-    "position": "rb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "ricky ortiz",
-    "first": "ricky",
-    "last": "ortiz",
-    "position": "fb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "julio jones",
-    "first": "julio",
-    "last": "jones",
-    "position": "wr"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "mohamed sanu",
-    "first": "mohamed",
-    "last": "sanu",
-    "position": "wr"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "calvin ridley",
-    "first": "calvin",
-    "last": "ridley",
-    "position": "wr"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "justin hardy",
-    "first": "justin",
-    "last": "hardy",
-    "position": "wr"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "russell gage",
-    "first": "russell",
-    "last": "gage",
-    "position": "wr"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "marcus green",
-    "first": "marcus",
-    "last": "green",
-    "position": "wr"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "christian blake",
-    "first": "christian",
-    "last": "blake",
-    "position": "wr"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "devin gray",
-    "first": "devin",
-    "last": "gray",
-    "position": "wr"
   },
   {
     "team": "atlanta falcons",
@@ -14082,58 +4922,42 @@
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "kahlil lewis",
-    "first": "kahlil",
-    "last": "lewis",
+    "fullname": "kenjon barner",
+    "first": "kenjon",
+    "last": "barner",
+    "position": "rb"
+  },
+  {
+    "team": "atlanta falcons",
+    "symbol": "ATL",
+    "fullname": "christian blake",
+    "first": "christian",
+    "last": "blake",
     "position": "wr"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "c.j. worton",
-    "first": "c.j.",
-    "last": "worton",
+    "fullname": "tony brooks-james",
+    "first": "tony",
+    "last": "brooks-james",
+    "position": "rb"
+  },
+  {
+    "team": "atlanta falcons",
+    "symbol": "ATL",
+    "fullname": "devonta freeman",
+    "first": "devonta",
+    "last": "freeman",
+    "position": "rb"
+  },
+  {
+    "team": "atlanta falcons",
+    "symbol": "ATL",
+    "fullname": "russell gage",
+    "first": "russell",
+    "last": "gage",
     "position": "wr"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "olamide zaccheaus",
-    "first": "olamide",
-    "last": "zaccheaus",
-    "position": "wr"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "austin hooper",
-    "first": "austin",
-    "last": "hooper",
-    "position": "te"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "luke stocker",
-    "first": "luke",
-    "last": "stocker",
-    "position": "te"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "logan paulsen",
-    "first": "logan",
-    "last": "paulsen",
-    "position": "te"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "eric saubert",
-    "first": "eric",
-    "last": "saubert",
-    "position": "te"
   },
   {
     "team": "atlanta falcons",
@@ -14154,498 +4978,146 @@
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "jake matthews",
-    "first": "jake",
-    "last": "matthews",
-    "position": "lt"
+    "fullname": "devin gray",
+    "first": "devin",
+    "last": "gray",
+    "position": "wr"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "ty sambrailo",
-    "first": "ty",
-    "last": "sambrailo",
-    "position": "lt"
+    "fullname": "marcus green",
+    "first": "marcus",
+    "last": "green",
+    "position": "wr"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "james carpenter",
-    "first": "james",
-    "last": "carpenter",
-    "position": "lg"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "sean harlow",
-    "first": "sean",
-    "last": "harlow",
-    "position": "lg"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "adam gettis",
-    "first": "adam",
-    "last": "gettis",
-    "position": "lg"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "alex mack",
-    "first": "alex",
-    "last": "mack",
-    "position": "c"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "wes schweitzer",
-    "first": "wes",
-    "last": "schweitzer",
-    "position": "c"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "chandler miller",
-    "first": "chandler",
-    "last": "miller",
-    "position": "c"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "chris lindstrom",
-    "first": "chris",
-    "last": "lindstrom",
-    "position": "rg"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "jamon brown",
-    "first": "jamon",
-    "last": "brown",
-    "position": "rg"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "kaleb mcgary",
-    "first": "kaleb",
-    "last": "mcgary",
-    "position": "rt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "matt gono",
-    "first": "matt",
-    "last": "gono",
-    "position": "rt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "john wetzel",
-    "first": "john",
-    "last": "wetzel",
-    "position": "rt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "dieugot joseph",
-    "first": "dieugot",
-    "last": "joseph",
-    "position": "rt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "grady jarrett",
-    "first": "grady",
-    "last": "jarrett",
-    "position": "ldt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "jack crawford",
-    "first": "jack",
-    "last": "crawford",
-    "position": "ldt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "justin zimmer",
+    "fullname": "justin hardy",
     "first": "justin",
-    "last": "zimmer",
-    "position": "ldt"
+    "last": "hardy",
+    "position": "wr"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "ra'shede hageman",
-    "first": "ra'shede",
-    "last": "hageman",
-    "position": "ldt"
+    "fullname": "brian hill",
+    "first": "brian",
+    "last": "hill",
+    "position": "rb"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "takkarist mckinley",
-    "first": "takkarist",
-    "last": "mckinley",
-    "position": "lde"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "adrian clayborn",
-    "first": "adrian",
-    "last": "clayborn",
-    "position": "lde"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "durrant miles",
-    "first": "durrant",
-    "last": "miles",
-    "position": "lde"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "austin larkin",
+    "fullname": "austin hooper",
     "first": "austin",
-    "last": "larkin",
-    "position": "lde"
+    "last": "hooper",
+    "position": "te"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "tyeler davison",
-    "first": "tyeler",
-    "last": "davison",
-    "position": "rdt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "deadrin senat",
-    "first": "deadrin",
-    "last": "senat",
-    "position": "rdt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "michael bennett",
-    "first": "michael",
-    "last": "bennett",
-    "position": "rdt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "jacob tuioti-mariner",
-    "first": "jacob",
-    "last": "tuioti-mariner",
-    "position": "rdt"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "vic beasley",
-    "first": "vic",
-    "last": "beasley",
-    "position": "rde"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "john cominsky",
-    "first": "john",
-    "last": "cominsky",
-    "position": "rde"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "chris odom",
-    "first": "chris",
-    "last": "odom",
-    "position": "rde"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "steven means",
-    "first": "steven",
-    "last": "means",
-    "position": "rde"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "deion jones",
-    "first": "deion",
+    "fullname": "julio jones",
+    "first": "julio",
     "last": "jones",
-    "position": "mlb"
+    "position": "wr"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "bruce carter",
-    "first": "bruce",
-    "last": "carter",
-    "position": "mlb"
+    "fullname": "kahlil lewis",
+    "first": "kahlil",
+    "last": "lewis",
+    "position": "wr"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "del'shawn phillips",
-    "first": "del'shawn",
-    "last": "phillips",
-    "position": "mlb"
+    "fullname": "qadree ollison",
+    "first": "qadree",
+    "last": "ollison",
+    "position": "rb"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "foye oluokun",
-    "first": "foye",
-    "last": "oluokun",
-    "position": "slb"
+    "fullname": "ricky ortiz",
+    "first": "ricky",
+    "last": "ortiz",
+    "position": "fb"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "duke riley",
-    "first": "duke",
-    "last": "riley",
-    "position": "slb"
+    "fullname": "logan paulsen",
+    "first": "logan",
+    "last": "paulsen",
+    "position": "te"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "yurik bethune",
-    "first": "yurik",
-    "last": "bethune",
-    "position": "slb"
+    "fullname": "calvin ridley",
+    "first": "calvin",
+    "last": "ridley",
+    "position": "wr"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "de'vondre campbell",
-    "first": "de'vondre",
-    "last": "campbell",
-    "position": "wlb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "kemal ishmael",
-    "first": "kemal",
-    "last": "ishmael",
-    "position": "wlb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "jermaine grace",
-    "first": "jermaine",
-    "last": "grace",
-    "position": "wlb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "tre' crawford",
-    "first": "tre'",
-    "last": "crawford",
-    "position": "wlb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "isaiah oliver",
-    "first": "isaiah",
-    "last": "oliver",
-    "position": "rcb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "kendall sheffield",
-    "first": "kendall",
-    "last": "sheffield",
-    "position": "rcb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "blidi wreh-wilson",
-    "first": "blidi",
-    "last": "wreh-wilson",
-    "position": "rcb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "jayson stanley",
-    "first": "jayson",
-    "last": "stanley",
-    "position": "rcb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "desmond trufant",
-    "first": "desmond",
-    "last": "trufant",
-    "position": "lcb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "damontae kazee",
-    "first": "damontae",
-    "last": "kazee",
-    "position": "lcb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "jordan miller",
-    "first": "jordan",
-    "last": "miller",
-    "position": "lcb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "taveze calhoun",
-    "first": "taveze",
-    "last": "calhoun",
-    "position": "lcb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "rashard causey",
-    "first": "rashard",
-    "last": "causey",
-    "position": "lcb"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "keanu neal",
-    "first": "keanu",
-    "last": "neal",
-    "position": "ss"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "j.j. wilcox",
-    "first": "j.j.",
-    "last": "wilcox",
-    "position": "ss"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "ryan neal",
-    "first": "ryan",
-    "last": "neal",
-    "position": "ss"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "chris cooper",
-    "first": "chris",
-    "last": "cooper",
-    "position": "ss"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "jason thompson",
-    "first": "jason",
-    "last": "thompson",
-    "position": "ss"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "ricardo allen",
-    "first": "ricardo",
-    "last": "allen",
-    "position": "fs"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "sharrod neasman",
-    "first": "sharrod",
-    "last": "neasman",
-    "position": "fs"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "parker baldwin",
-    "first": "parker",
-    "last": "baldwin",
-    "position": "fs"
-  },
-  {
-    "team": "atlanta falcons",
-    "symbol": "ATL",
-    "fullname": "matt bosher",
+    "fullname": "matt ryan",
     "first": "matt",
-    "last": "bosher",
-    "position": "p"
+    "last": "ryan",
+    "position": "qb"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "josh harris",
-    "first": "josh",
-    "last": "harris",
-    "position": "ls"
+    "fullname": "mohamed sanu",
+    "first": "mohamed",
+    "last": "sanu",
+    "position": "wr"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "kyle vasey",
-    "first": "kyle",
-    "last": "vasey",
-    "position": "ls"
+    "fullname": "eric saubert",
+    "first": "eric",
+    "last": "saubert",
+    "position": "te"
   },
   {
     "team": "atlanta falcons",
     "symbol": "ATL",
-    "fullname": "matt bosher",
+    "fullname": "matt schaub",
     "first": "matt",
-    "last": "bosher",
-    "position": "h"
+    "last": "schaub",
+    "position": "qb"
+  },
+  {
+    "team": "atlanta falcons",
+    "symbol": "ATL",
+    "fullname": "matt simms",
+    "first": "matt",
+    "last": "simms",
+    "position": "qb"
+  },
+  {
+    "team": "atlanta falcons",
+    "symbol": "ATL",
+    "fullname": "ito smith",
+    "first": "ito",
+    "last": "smith",
+    "position": "rb"
+  },
+  {
+    "team": "atlanta falcons",
+    "symbol": "ATL",
+    "fullname": "luke stocker",
+    "first": "luke",
+    "last": "stocker",
+    "position": "te"
   },
   {
     "team": "atlanta falcons",
@@ -14653,6 +5125,78 @@
     "fullname": "giorgio tavecchio",
     "first": "giorgio",
     "last": "tavecchio",
+    "position": "k"
+  },
+  {
+    "team": "atlanta falcons",
+    "symbol": "ATL",
+    "fullname": "cj worton",
+    "first": "cj",
+    "last": "worton",
+    "position": "wr"
+  },
+  {
+    "team": "atlanta falcons",
+    "symbol": "ATL",
+    "fullname": "olamide zaccheaus",
+    "first": "olamide",
+    "last": "zaccheaus",
+    "position": "wr"
+  },
+  {
+    "team": "atlanta falcons",
+    "symbol": "ATL",
+    "fullname": "kurt benkert",
+    "first": "kurt",
+    "last": "benkert",
+    "position": "qb"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "marcell ateman",
+    "first": "marcell",
+    "last": "ateman",
+    "position": "wr"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "antonio brown",
+    "first": "antonio",
+    "last": "brown",
+    "position": "wr"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "mack brown",
+    "first": "mack",
+    "last": "brown",
+    "position": "rb"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "james butler",
+    "first": "james",
+    "last": "butler",
+    "position": "rb"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "paul butler",
+    "first": "paul",
+    "last": "butler",
+    "position": "te"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "daniel carlson",
+    "first": "daniel",
+    "last": "carlson",
     "position": "k"
   },
   {
@@ -14666,6 +5210,22 @@
   {
     "team": "oakland raiders",
     "symbol": "OAK",
+    "fullname": "derek carrier",
+    "first": "derek",
+    "last": "carrier",
+    "position": "te"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "keelan doss",
+    "first": "keelan",
+    "last": "doss",
+    "position": "wr"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
     "fullname": "mike glennon",
     "first": "mike",
     "last": "glennon",
@@ -14674,121 +5234,9 @@
   {
     "team": "oakland raiders",
     "symbol": "OAK",
-    "fullname": "nathan peterman",
-    "first": "nathan",
-    "last": "peterman",
-    "position": "qb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "josh jacobs",
-    "first": "josh",
-    "last": "jacobs",
-    "position": "rb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "jalen richard",
-    "first": "jalen",
-    "last": "richard",
-    "position": "rb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "doug martin",
-    "first": "doug",
-    "last": "martin",
-    "position": "rb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "deandre washington",
-    "first": "deandre",
-    "last": "washington",
-    "position": "rb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "chris warren",
-    "first": "chris",
-    "last": "warren",
-    "position": "rb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "isaiah crowell",
-    "first": "isaiah",
-    "last": "crowell",
-    "position": "rb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "keith smith",
-    "first": "keith",
-    "last": "smith",
-    "position": "fb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "ryan yurachek",
-    "first": "ryan",
-    "last": "yurachek",
-    "position": "fb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "antonio brown",
-    "first": "antonio",
-    "last": "brown",
-    "position": "wr"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "tyrell williams",
-    "first": "tyrell",
-    "last": "williams",
-    "position": "wr"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
     "fullname": "ryan grant",
     "first": "ryan",
     "last": "grant",
-    "position": "wr"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "j.j. nelson",
-    "first": "j.j.",
-    "last": "nelson",
-    "position": "wr"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "hunter renfrow",
-    "first": "hunter",
-    "last": "renfrow",
-    "position": "wr"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "marcell ateman",
-    "first": "marcell",
-    "last": "ateman",
     "position": "wr"
   },
   {
@@ -14810,42 +5258,34 @@
   {
     "team": "oakland raiders",
     "symbol": "OAK",
-    "fullname": "keelan doss",
-    "first": "keelan",
-    "last": "doss",
+    "fullname": "alec ingold",
+    "first": "alec",
+    "last": "ingold",
+    "position": "fb"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "josh jacobs",
+    "first": "josh",
+    "last": "jacobs",
+    "position": "rb"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "jordan lasley",
+    "first": "jordan",
+    "last": "lasley",
     "position": "wr"
   },
   {
     "team": "oakland raiders",
     "symbol": "OAK",
-    "fullname": "saeed blacknall",
-    "first": "saeed",
-    "last": "blacknall",
-    "position": "wr"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "brian burt",
-    "first": "brian",
-    "last": "burt",
-    "position": "wr"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "darren waller",
-    "first": "darren",
-    "last": "waller",
-    "position": "te"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "luke willson",
-    "first": "luke",
-    "last": "willson",
-    "position": "te"
+    "fullname": "doug martin",
+    "first": "doug",
+    "last": "martin",
+    "position": "rb"
   },
   {
     "team": "oakland raiders",
@@ -14858,585 +5298,89 @@
   {
     "team": "oakland raiders",
     "symbol": "OAK",
-    "fullname": "erik swoope",
-    "first": "erik",
-    "last": "swoope",
-    "position": "te"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "derek carrier",
-    "first": "derek",
-    "last": "carrier",
-    "position": "te"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "paul butler",
-    "first": "paul",
-    "last": "butler",
-    "position": "te"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "kolton miller",
-    "first": "kolton",
-    "last": "miller",
-    "position": "lt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "david sharpe",
-    "first": "david",
-    "last": "sharpe",
-    "position": "lt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "tyler roemer",
-    "first": "tyler",
-    "last": "roemer",
-    "position": "lt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "richie incognito",
-    "first": "richie",
-    "last": "incognito",
-    "position": "lg"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "denzelle good",
-    "first": "denzelle",
-    "last": "good",
-    "position": "lg"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "lester cotton",
-    "first": "lester",
-    "last": "cotton",
-    "position": "lg"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "rodney hudson",
-    "first": "rodney",
-    "last": "hudson",
-    "position": "c"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "jordan devey",
-    "first": "jordan",
-    "last": "devey",
-    "position": "c"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "maxx crosby",
-    "first": "maxx",
-    "last": "crosby",
-    "position": "c"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "gabe jackson",
-    "first": "gabe",
-    "last": "jackson",
-    "position": "rg"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "denver kirkland",
-    "first": "denver",
-    "last": "kirkland",
-    "position": "rg"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "trent brown",
-    "first": "trent",
-    "last": "brown",
-    "position": "rt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "brandon parker",
-    "first": "brandon",
-    "last": "parker",
-    "position": "rt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "justin murray",
-    "first": "justin",
-    "last": "murray",
-    "position": "rt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "andre james",
-    "first": "andre",
-    "last": "james",
-    "position": "rt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "maurice hurst",
-    "first": "maurice",
-    "last": "hurst",
-    "position": "ldt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "p.j. hall",
-    "first": "p.j.",
-    "last": "hall",
-    "position": "ldt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "eddie vanderdoes",
-    "first": "eddie",
-    "last": "vanderdoes",
-    "position": "ldt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "gabe wright",
-    "first": "gabe",
-    "last": "wright",
-    "position": "ldt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "clelin ferrell",
-    "first": "clelin",
-    "last": "ferrell",
-    "position": "lde"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "alex barrett",
-    "first": "alex",
-    "last": "barrett",
-    "position": "lde"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "josh mauro",
-    "first": "josh",
-    "last": "mauro",
-    "position": "lde"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "benson mayowa",
-    "first": "benson",
-    "last": "mayowa",
-    "position": "lde"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "johnathan hankins",
-    "first": "johnathan",
-    "last": "hankins",
-    "position": "rdt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "justin ellis",
-    "first": "justin",
-    "last": "ellis",
-    "position": "rdt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "ronald ollie",
-    "first": "ronald",
-    "last": "ollie",
-    "position": "rdt"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "arden key",
-    "first": "arden",
-    "last": "key",
-    "position": "rde"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "maxx crosby",
-    "first": "maxx",
-    "last": "crosby",
-    "position": "rde"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "brandon marshall",
-    "first": "brandon",
-    "last": "marshall",
-    "position": "mlb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "jason cabinda",
-    "first": "jason",
-    "last": "cabinda",
-    "position": "mlb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "kyle wilber",
-    "first": "kyle",
-    "last": "wilber",
-    "position": "mlb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "te'von coney",
-    "first": "te'von",
-    "last": "coney",
-    "position": "mlb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "tahir whitehead",
-    "first": "tahir",
-    "last": "whitehead",
-    "position": "slb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "marquel lee",
-    "first": "marquel",
-    "last": "lee",
-    "position": "slb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "james cowser",
-    "first": "james",
-    "last": "cowser",
-    "position": "slb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "quinton bell",
-    "first": "quinton",
-    "last": "bell",
-    "position": "slb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "vontaze burfict",
-    "first": "vontaze",
-    "last": "burfict",
-    "position": "wlb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "nicholas morrow",
-    "first": "nicholas",
-    "last": "morrow",
-    "position": "wlb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "koa farmer",
-    "first": "koa",
-    "last": "farmer",
-    "position": "wlb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "daryl worley",
-    "first": "daryl",
-    "last": "worley",
-    "position": "rcb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "lamarcus joyner",
-    "first": "lamarcus",
-    "last": "joyner",
-    "position": "rcb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "nick nelson",
-    "first": "nick",
+    "fullname": "jj nelson",
+    "first": "jj",
     "last": "nelson",
-    "position": "rcb"
+    "position": "wr"
   },
   {
     "team": "oakland raiders",
     "symbol": "OAK",
-    "fullname": "isaiah langley",
+    "fullname": "nathan peterman",
+    "first": "nathan",
+    "last": "peterman",
+    "position": "qb"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "de'mornay pierson-el",
+    "first": "de'mornay",
+    "last": "pierson-el",
+    "position": "wr"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "hunter renfrow",
+    "first": "hunter",
+    "last": "renfrow",
+    "position": "wr"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "jalen richard",
+    "first": "jalen",
+    "last": "richard",
+    "position": "rb"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "keith smith",
+    "first": "keith",
+    "last": "smith",
+    "position": "fb"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "darren waller",
+    "first": "darren",
+    "last": "waller",
+    "position": "te"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "deandre washington",
+    "first": "deandre",
+    "last": "washington",
+    "position": "rb"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "tyrell williams",
+    "first": "tyrell",
+    "last": "williams",
+    "position": "wr"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "luke willson",
+    "first": "luke",
+    "last": "willson",
+    "position": "te"
+  },
+  {
+    "team": "oakland raiders",
+    "symbol": "OAK",
+    "fullname": "isaiah crowell",
     "first": "isaiah",
-    "last": "langley",
-    "position": "rcb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "gareon conley",
-    "first": "gareon",
-    "last": "conley",
-    "position": "lcb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "trayvon mullen",
-    "first": "trayvon",
-    "last": "mullen",
-    "position": "lcb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "nevin lawson",
-    "first": "nevin",
-    "last": "lawson",
-    "position": "lcb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "isaiah johnson",
-    "first": "isaiah",
-    "last": "johnson",
-    "position": "lcb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "rico gafford",
-    "first": "rico",
-    "last": "gafford",
-    "position": "lcb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "keisean nixon",
-    "first": "keisean",
-    "last": "nixon",
-    "position": "lcb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "dylan mabin",
-    "first": "dylan",
-    "last": "mabin",
-    "position": "lcb"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "karl joseph",
-    "first": "karl",
-    "last": "joseph",
-    "position": "ss"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "jordan richards",
-    "first": "jordan",
-    "last": "richards",
-    "position": "ss"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "dallin leavitt",
-    "first": "dallin",
-    "last": "leavitt",
-    "position": "ss"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "johnathan abram",
-    "first": "johnathan",
-    "last": "abram",
-    "position": "fs"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "erik harris",
-    "first": "erik",
-    "last": "harris",
-    "position": "fs"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "curtis riley",
-    "first": "curtis",
-    "last": "riley",
-    "position": "fs"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "johnny townsend",
-    "first": "johnny",
-    "last": "townsend",
-    "position": "p"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "a.j. cole",
-    "first": "a.j.",
-    "last": "cole",
-    "position": "p"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "andrew depaola",
-    "first": "andrew",
-    "last": "depaola",
-    "position": "ls"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "johnny townsend",
-    "first": "johnny",
-    "last": "townsend",
-    "position": "h"
-  },
-  {
-    "team": "oakland raiders",
-    "symbol": "OAK",
-    "fullname": "daniel carlson",
-    "first": "daniel",
-    "last": "carlson",
-    "position": "k"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "carson wentz",
-    "first": "carson",
-    "last": "wentz",
-    "position": "qb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "nate sudfeld",
-    "first": "nate",
-    "last": "sudfeld",
-    "position": "qb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "clayton thorson",
-    "first": "clayton",
-    "last": "thorson",
-    "position": "qb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "cody kessler",
-    "first": "cody",
-    "last": "kessler",
-    "position": "qb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "jordan howard",
-    "first": "jordan",
-    "last": "howard",
-    "position": "rb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "miles sanders",
-    "first": "miles",
-    "last": "sanders",
-    "position": "rb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "corey clement",
-    "first": "corey",
-    "last": "clement",
-    "position": "rb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "wendell smallwood",
-    "first": "wendell",
-    "last": "smallwood",
+    "last": "crowell",
     "position": "rb"
   },
   {
@@ -15450,105 +5394,9 @@
   {
     "team": "philadelphia eagles",
     "symbol": "PHI",
-    "fullname": "boston scott",
-    "first": "boston",
-    "last": "scott",
-    "position": "rb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "donnel pumphrey",
-    "first": "donnel",
-    "last": "pumphrey",
-    "position": "rb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "fb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "alshon jeffery",
-    "first": "alshon",
-    "last": "jeffery",
-    "position": "wr"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "desean jackson",
-    "first": "desean",
-    "last": "jackson",
-    "position": "wr"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
     "fullname": "nelson agholor",
     "first": "nelson",
     "last": "agholor",
-    "position": "wr"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "j.j. arcega-whiteside",
-    "first": "j.j.",
-    "last": "arcega-whiteside",
-    "position": "wr"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "mack hollins",
-    "first": "mack",
-    "last": "hollins",
-    "position": "wr"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "shelton gibson",
-    "first": "shelton",
-    "last": "gibson",
-    "position": "wr"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "charles d. johnson",
-    "first": "charles",
-    "last": "d.",
-    "position": "wr"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "braxton miller",
-    "first": "braxton",
-    "last": "miller",
-    "position": "wr"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "greg ward",
-    "first": "greg",
-    "last": "ward",
-    "position": "wr"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "marken michel",
-    "first": "marken",
-    "last": "michel",
     "position": "wr"
   },
   {
@@ -15562,18 +5410,34 @@
   {
     "team": "philadelphia eagles",
     "symbol": "PHI",
-    "fullname": "deandre thompkins",
-    "first": "deandre",
-    "last": "thompkins",
+    "fullname": "jj arcega-whiteside",
+    "first": "jj",
+    "last": "arcega-whiteside",
     "position": "wr"
   },
   {
     "team": "philadelphia eagles",
     "symbol": "PHI",
-    "fullname": "devin ross",
-    "first": "devin",
-    "last": "ross",
-    "position": "wr"
+    "fullname": "corey clement",
+    "first": "corey",
+    "last": "clement",
+    "position": "rb"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "jake elliott",
+    "first": "jake",
+    "last": "elliott",
+    "position": "k"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "alex ellis",
+    "first": "alex",
+    "last": "ellis",
+    "position": "te"
   },
   {
     "team": "philadelphia eagles",
@@ -15586,10 +5450,98 @@
   {
     "team": "philadelphia eagles",
     "symbol": "PHI",
+    "fullname": "shelton gibson",
+    "first": "shelton",
+    "last": "gibson",
+    "position": "wr"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
     "fullname": "dallas goedert",
     "first": "dallas",
     "last": "goedert",
     "position": "te"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "mack hollins",
+    "first": "mack",
+    "last": "hollins",
+    "position": "wr"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "jordan howard",
+    "first": "jordan",
+    "last": "howard",
+    "position": "rb"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "desean jackson",
+    "first": "desean",
+    "last": "jackson",
+    "position": "wr"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "alshon jeffery",
+    "first": "alshon",
+    "last": "jeffery",
+    "position": "wr"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "charles johnson",
+    "first": "charles",
+    "last": "johnson",
+    "position": "wr"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "cody kessler",
+    "first": "cody",
+    "last": "kessler",
+    "position": "qb"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "marken michel",
+    "first": "marken",
+    "last": "michel",
+    "position": "wr"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "braxton miller",
+    "first": "braxton",
+    "last": "miller",
+    "position": "wr"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "joshua perkins",
+    "first": "joshua",
+    "last": "perkins",
+    "position": "te"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "donnel pumphrey",
+    "first": "donnel",
+    "last": "pumphrey",
+    "position": "rb"
   },
   {
     "team": "philadelphia eagles",
@@ -15602,10 +5554,58 @@
   {
     "team": "philadelphia eagles",
     "symbol": "PHI",
-    "fullname": "josh perkins",
-    "first": "josh",
-    "last": "perkins",
-    "position": "te"
+    "fullname": "miles sanders",
+    "first": "miles",
+    "last": "sanders",
+    "position": "rb"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "boston scott",
+    "first": "boston",
+    "last": "scott",
+    "position": "rb"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "wendell smallwood",
+    "first": "wendell",
+    "last": "smallwood",
+    "position": "rb"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "darren sproles",
+    "first": "darren",
+    "last": "sproles",
+    "position": "rb"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "nate sudfeld",
+    "first": "nate",
+    "last": "sudfeld",
+    "position": "qb"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "deandre thompkins",
+    "first": "deandre",
+    "last": "thompkins",
+    "position": "wr"
+  },
+  {
+    "team": "philadelphia eagles",
+    "symbol": "PHI",
+    "fullname": "clayton thorson",
+    "first": "clayton",
+    "last": "thorson",
+    "position": "qb"
   },
   {
     "team": "philadelphia eagles",
@@ -15618,529 +5618,25 @@
   {
     "team": "philadelphia eagles",
     "symbol": "PHI",
-    "fullname": "jason peters",
-    "first": "jason",
-    "last": "peters",
-    "position": "lt"
+    "fullname": "greg ward jr.",
+    "first": "greg",
+    "last": "ward jr.",
+    "position": "wr"
   },
   {
     "team": "philadelphia eagles",
     "symbol": "PHI",
-    "fullname": "andre dillard",
-    "first": "andre",
-    "last": "dillard",
-    "position": "lt"
+    "fullname": "carson wentz",
+    "first": "carson",
+    "last": "wentz",
+    "position": "qb"
   },
   {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "jordan mailata",
-    "first": "jordan",
-    "last": "mailata",
-    "position": "lt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "casey tucker",
-    "first": "casey",
-    "last": "tucker",
-    "position": "lt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "isaac seumalo",
-    "first": "isaac",
-    "last": "seumalo",
-    "position": "lg"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "stefen wisniewski",
-    "first": "stefen",
-    "last": "wisniewski",
-    "position": "lg"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "ryan bates",
-    "first": "ryan",
-    "last": "bates",
-    "position": "lg"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "jason kelce",
-    "first": "jason",
-    "last": "kelce",
-    "position": "c"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "anthony fabiano",
-    "first": "anthony",
-    "last": "fabiano",
-    "position": "c"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "keegan render",
-    "first": "keegan",
-    "last": "render",
-    "position": "c"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "brandon brooks",
-    "first": "brandon",
-    "last": "brooks",
-    "position": "rg"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "matt pryor",
-    "first": "matt",
-    "last": "pryor",
-    "position": "rg"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "nate herbig",
-    "first": "nate",
-    "last": "herbig",
-    "position": "rg"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "lane johnson",
-    "first": "lane",
-    "last": "johnson",
-    "position": "rt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "halapoulivaati vaitai",
-    "first": "halapoulivaati",
-    "last": "vaitai",
-    "position": "rt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "fletcher cox",
-    "first": "fletcher",
-    "last": "cox",
-    "position": "ldt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "hassan ridgeway",
-    "first": "hassan",
-    "last": "ridgeway",
-    "position": "ldt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "treyvon hester",
-    "first": "treyvon",
-    "last": "hester",
-    "position": "ldt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "kevin wilkins",
-    "first": "kevin",
-    "last": "wilkins",
-    "position": "ldt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "brandon graham",
-    "first": "brandon",
-    "last": "graham",
-    "position": "lde"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "joe ostman",
-    "first": "joe",
-    "last": "ostman",
-    "position": "lde"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "daeshon hall",
-    "first": "daeshon",
-    "last": "hall",
-    "position": "lde"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "malik jackson",
-    "first": "malik",
-    "last": "jackson",
-    "position": "rdt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "timmy jernigan",
-    "first": "timmy",
-    "last": "jernigan",
-    "position": "rdt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "bruce hector",
-    "first": "bruce",
-    "last": "hector",
-    "position": "rdt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "anthony rush",
-    "first": "anthony",
-    "last": "rush",
-    "position": "rdt"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "derek barnett",
-    "first": "derek",
-    "last": "barnett",
-    "position": "rde"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "vinny curry",
-    "first": "vinny",
-    "last": "curry",
-    "position": "rde"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "shareef miller",
-    "first": "shareef",
-    "last": "miller",
-    "position": "rde"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "josh sweat",
-    "first": "josh",
-    "last": "sweat",
-    "position": "rde"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "zach brown",
-    "first": "zach",
-    "last": "brown",
-    "position": "mlb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "l.j. fort",
-    "first": "l.j.",
-    "last": "fort",
-    "position": "mlb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "paul worrilow",
-    "first": "paul",
-    "last": "worrilow",
-    "position": "mlb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "alex singleton",
-    "first": "alex",
-    "last": "singleton",
-    "position": "mlb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "kamu grugier-hill",
-    "first": "kamu",
-    "last": "grugier-hill",
-    "position": "slb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "nate gerry",
-    "first": "nate",
-    "last": "gerry",
-    "position": "slb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "joey alfieri",
-    "first": "joey",
-    "last": "alfieri",
-    "position": "slb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "nigel bradham",
-    "first": "nigel",
-    "last": "bradham",
-    "position": "wlb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "t.j. edwards",
-    "first": "t.j.",
-    "last": "edwards",
-    "position": "wlb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "jalen mills",
-    "first": "jalen",
-    "last": "mills",
-    "position": "rcb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "cre'von leblanc",
-    "first": "cre'von",
-    "last": "leblanc",
-    "position": "rcb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "sidney jones",
-    "first": "sidney",
-    "last": "jones",
-    "position": "rcb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "jeremiah mckinnon",
-    "first": "jeremiah",
-    "last": "mckinnon",
-    "position": "rcb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "ronald darby",
-    "first": "ronald",
-    "last": "darby",
-    "position": "lcb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "avonte maddox",
-    "first": "avonte",
-    "last": "maddox",
-    "position": "lcb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "rasul douglas",
-    "first": "rasul",
-    "last": "douglas",
-    "position": "lcb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "josh hawkins",
-    "first": "josh",
-    "last": "hawkins",
-    "position": "lcb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "jay liggins",
-    "first": "jay",
-    "last": "liggins",
-    "position": "lcb"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "malcolm jenkins",
-    "first": "malcolm",
-    "last": "jenkins",
-    "position": "ss"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "andrew sendejo",
-    "first": "andrew",
-    "last": "sendejo",
-    "position": "ss"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "deiondre' hall",
-    "first": "deiondre'",
-    "last": "hall",
-    "position": "ss"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "godwin igwebuike",
-    "first": "godwin",
-    "last": "igwebuike",
-    "position": "ss"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "rodney mcleod",
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "rodney anderson",
     "first": "rodney",
-    "last": "mcleod",
-    "position": "fs"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "tre sullivan",
-    "first": "tre",
-    "last": "sullivan",
-    "position": "fs"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "blake countess",
-    "first": "blake",
-    "last": "countess",
-    "position": "fs"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "trae elston",
-    "first": "trae",
-    "last": "elston",
-    "position": "fs"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "cameron johnston",
-    "first": "cameron",
-    "last": "johnston",
-    "position": "p"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "rick lovato",
-    "first": "rick",
-    "last": "lovato",
-    "position": "ls"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "cameron johnston",
-    "first": "cameron",
-    "last": "johnston",
-    "position": "h"
-  },
-  {
-    "team": "philadelphia eagles",
-    "symbol": "PHI",
-    "fullname": "jake elliott",
-    "first": "jake",
-    "last": "elliott",
-    "position": "k"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "andy dalton",
-    "first": "andy",
-    "last": "dalton",
-    "position": "qb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "jeff driskel",
-    "first": "jeff",
-    "last": "driskel",
-    "position": "qb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "ryan finley",
-    "first": "ryan",
-    "last": "finley",
-    "position": "qb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "jake dolegala",
-    "first": "jake",
-    "last": "dolegala",
-    "position": "qb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "joe mixon",
-    "first": "joe",
-    "last": "mixon",
+    "last": "anderson",
     "position": "rb"
   },
   {
@@ -16154,57 +5650,9 @@
   {
     "team": "cincinnati bengals",
     "symbol": "CIN",
-    "fullname": "trayveon williams",
-    "first": "trayveon",
-    "last": "williams",
-    "position": "rb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "rodney anderson",
-    "first": "rodney",
-    "last": "anderson",
-    "position": "rb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "quinton flowers",
-    "first": "quinton",
-    "last": "flowers",
-    "position": "rb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "darrin hall",
-    "first": "darrin",
-    "last": "hall",
-    "position": "rb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "jordan ellis",
-    "first": "jordan",
-    "last": "ellis",
-    "position": "rb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "fb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "a.j. green",
-    "first": "a.j.",
-    "last": "green",
+    "fullname": "moritz boehringer",
+    "first": "moritz",
+    "last": "boehringer",
     "position": "wr"
   },
   {
@@ -16218,10 +5666,74 @@
   {
     "team": "cincinnati bengals",
     "symbol": "CIN",
-    "fullname": "john ross",
-    "first": "john",
-    "last": "ross",
+    "fullname": "ventell bryant",
+    "first": "ventell",
+    "last": "bryant",
     "position": "wr"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "randy bullock",
+    "first": "randy",
+    "last": "bullock",
+    "position": "k"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "cethan carter",
+    "first": "cethan",
+    "last": "carter",
+    "position": "te"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "cody core",
+    "first": "cody",
+    "last": "core",
+    "position": "wr"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "andy dalton",
+    "first": "andy",
+    "last": "dalton",
+    "position": "qb"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "jacob dolegala",
+    "first": "jacob",
+    "last": "dolegala",
+    "position": "qb"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "jeff driskel",
+    "first": "jeff",
+    "last": "driskel",
+    "position": "qb"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "tyler eifert",
+    "first": "tyler",
+    "last": "eifert",
+    "position": "te"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "jordan ellis",
+    "first": "jordan",
+    "last": "ellis",
+    "position": "rb"
   },
   {
     "team": "cincinnati bengals",
@@ -16229,6 +5741,38 @@
     "fullname": "alex erickson",
     "first": "alex",
     "last": "erickson",
+    "position": "wr"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "ryan finley",
+    "first": "ryan",
+    "last": "finley",
+    "position": "qb"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "quinton flowers",
+    "first": "quinton",
+    "last": "flowers",
+    "position": "rb"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "jordan franks",
+    "first": "jordan",
+    "last": "franks",
+    "position": "te"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "aj green",
+    "first": "aj",
+    "last": "green",
     "position": "wr"
   },
   {
@@ -16242,74 +5786,26 @@
   {
     "team": "cincinnati bengals",
     "symbol": "CIN",
-    "fullname": "cody core",
-    "first": "cody",
-    "last": "core",
-    "position": "wr"
+    "fullname": "joe mixon",
+    "first": "joe",
+    "last": "mixon",
+    "position": "rb"
   },
   {
     "team": "cincinnati bengals",
     "symbol": "CIN",
-    "fullname": "auden tate",
-    "first": "auden",
-    "last": "tate",
-    "position": "wr"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "hunter sharp",
-    "first": "hunter",
-    "last": "sharp",
-    "position": "wr"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "stanley morgan",
+    "fullname": "stanley morgan jr.",
     "first": "stanley",
-    "last": "morgan",
+    "last": "morgan jr.",
     "position": "wr"
   },
   {
     "team": "cincinnati bengals",
     "symbol": "CIN",
-    "fullname": "kermit whitfield",
-    "first": "kermit",
-    "last": "whitfield",
+    "fullname": "john ross iii",
+    "first": "john",
+    "last": "ross iii",
     "position": "wr"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "damion willis",
-    "first": "damion",
-    "last": "willis",
-    "position": "wr"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "ventell bryant",
-    "first": "ventell",
-    "last": "bryant",
-    "position": "wr"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "tyler eifert",
-    "first": "tyler",
-    "last": "eifert",
-    "position": "te"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "c.j. uzomah",
-    "first": "c.j.",
-    "last": "uzomah",
-    "position": "te"
   },
   {
     "team": "cincinnati bengals",
@@ -16330,490 +5826,26 @@
   {
     "team": "cincinnati bengals",
     "symbol": "CIN",
-    "fullname": "cethan carter",
-    "first": "cethan",
-    "last": "carter",
+    "fullname": "hunter sharp",
+    "first": "hunter",
+    "last": "sharp",
+    "position": "wr"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "auden tate",
+    "first": "auden",
+    "last": "tate",
+    "position": "wr"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "cj uzomah",
+    "first": "cj",
+    "last": "uzomah",
     "position": "te"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "jordan franks",
-    "first": "jordan",
-    "last": "franks",
-    "position": "te"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "moritz boehringer",
-    "first": "moritz",
-    "last": "boehringer",
-    "position": "te"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "cordy glenn",
-    "first": "cordy",
-    "last": "glenn",
-    "position": "lt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "jonah williams",
-    "first": "jonah",
-    "last": "williams",
-    "position": "lt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "john jerry",
-    "first": "john",
-    "last": "jerry",
-    "position": "lg"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "keaton sutherland",
-    "first": "keaton",
-    "last": "sutherland",
-    "position": "lg"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "billy price",
-    "first": "billy",
-    "last": "price",
-    "position": "c"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "trey hopkins",
-    "first": "trey",
-    "last": "hopkins",
-    "position": "c"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "brad lundblade",
-    "first": "brad",
-    "last": "lundblade",
-    "position": "c"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "john miller",
-    "first": "john",
-    "last": "miller",
-    "position": "rg"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "christian westerman",
-    "first": "christian",
-    "last": "westerman",
-    "position": "rg"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "o'shea dugas",
-    "first": "o'shea",
-    "last": "dugas",
-    "position": "rg"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "bobby hart",
-    "first": "bobby",
-    "last": "hart",
-    "position": "rt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "kent perkins",
-    "first": "kent",
-    "last": "perkins",
-    "position": "rt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "andrew billings",
-    "first": "andrew",
-    "last": "billings",
-    "position": "ldt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "renell wren",
-    "first": "renell",
-    "last": "wren",
-    "position": "ldt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "niles scott",
-    "first": "niles",
-    "last": "scott",
-    "position": "ldt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "josh tupou",
-    "first": "josh",
-    "last": "tupou",
-    "position": "ldt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "carlos dunlap",
-    "first": "carlos",
-    "last": "dunlap",
-    "position": "lde"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "sam hubbard",
-    "first": "sam",
-    "last": "hubbard",
-    "position": "lde"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "andrew brown",
-    "first": "andrew",
-    "last": "brown",
-    "position": "lde"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "geno atkins",
-    "first": "geno",
-    "last": "atkins",
-    "position": "rdt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "ryan glasgow",
-    "first": "ryan",
-    "last": "glasgow",
-    "position": "rdt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "christian ringo",
-    "first": "christian",
-    "last": "ringo",
-    "position": "rdt"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "jordan willis",
-    "first": "jordan",
-    "last": "willis",
-    "position": "rde"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "kerry wynn",
-    "first": "kerry",
-    "last": "wynn",
-    "position": "rde"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "carl lawson",
-    "first": "carl",
-    "last": "lawson",
-    "position": "rde"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "preston brown",
-    "first": "preston",
-    "last": "brown",
-    "position": "mlb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "hardy nickerson",
-    "first": "hardy",
-    "last": "nickerson",
-    "position": "mlb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "deshaun davis",
-    "first": "deshaun",
-    "last": "davis",
-    "position": "mlb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "curtis akins",
-    "first": "curtis",
-    "last": "akins",
-    "position": "mlb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "nick vigil",
-    "first": "nick",
-    "last": "vigil",
-    "position": "slb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "malik jefferson",
-    "first": "malik",
-    "last": "jefferson",
-    "position": "slb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "chris worley",
-    "first": "chris",
-    "last": "worley",
-    "position": "slb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "jordan evans",
-    "first": "jordan",
-    "last": "evans",
-    "position": "wlb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "germaine pratt",
-    "first": "germaine",
-    "last": "pratt",
-    "position": "wlb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "sterling sheffield",
-    "first": "sterling",
-    "last": "sheffield",
-    "position": "wlb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "noah dawkins",
-    "first": "noah",
-    "last": "dawkins",
-    "position": "wlb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "william jackson",
-    "first": "william",
-    "last": "jackson",
-    "position": "rcb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "tony mcrae",
-    "first": "tony",
-    "last": "mcrae",
-    "position": "rcb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "darius phillips",
-    "first": "darius",
-    "last": "phillips",
-    "position": "rcb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "jordan brown",
-    "first": "jordan",
-    "last": "brown",
-    "position": "rcb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "anthony chesley",
-    "first": "anthony",
-    "last": "chesley",
-    "position": "rcb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "dre kirkpatrick",
-    "first": "dre",
-    "last": "kirkpatrick",
-    "position": "lcb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "darqueze dennard",
-    "first": "darqueze",
-    "last": "dennard",
-    "position": "lcb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "b.w. webb",
-    "first": "b.w.",
-    "last": "webb",
-    "position": "lcb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "davontae harris",
-    "first": "davontae",
-    "last": "harris",
-    "position": "lcb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "keivarae russell",
-    "first": "keivarae",
-    "last": "russell",
-    "position": "lcb"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "shawn williams",
-    "first": "shawn",
-    "last": "williams",
-    "position": "ss"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "clayton fejedelem",
-    "first": "clayton",
-    "last": "fejedelem",
-    "position": "ss"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "tyree kinnel",
-    "first": "tyree",
-    "last": "kinnel",
-    "position": "ss"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "jessie bates",
-    "first": "jessie",
-    "last": "bates",
-    "position": "fs"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "brandon wilson",
-    "first": "brandon",
-    "last": "wilson",
-    "position": "fs"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "trayvon henderson",
-    "first": "trayvon",
-    "last": "henderson",
-    "position": "fs"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "demetrious cox",
-    "first": "demetrious",
-    "last": "cox",
-    "position": "fs"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "kevin huber",
-    "first": "kevin",
-    "last": "huber",
-    "position": "p"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "clark harris",
-    "first": "clark",
-    "last": "harris",
-    "position": "ls"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "kevin huber",
-    "first": "kevin",
-    "last": "huber",
-    "position": "h"
-  },
-  {
-    "team": "cincinnati bengals",
-    "symbol": "CIN",
-    "fullname": "randy bullock",
-    "first": "randy",
-    "last": "bullock",
-    "position": "k"
   },
   {
     "team": "cincinnati bengals",
@@ -16824,11 +5856,91 @@
     "position": "k"
   },
   {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "trayveon williams",
+    "first": "trayveon",
+    "last": "williams",
+    "position": "rb"
+  },
+  {
+    "team": "cincinnati bengals",
+    "symbol": "CIN",
+    "fullname": "damion willis",
+    "first": "damion",
+    "last": "willis",
+    "position": "wr"
+  },
+  {
     "team": "tampa bay buccaneers",
     "symbol": "TB",
-    "fullname": "jameis winston",
-    "first": "jameis",
-    "last": "winston",
+    "fullname": "bruce anderson",
+    "first": "bruce",
+    "last": "anderson",
+    "position": "rb"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "antony auclair",
+    "first": "antony",
+    "last": "auclair",
+    "position": "te"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "peyton barber",
+    "first": "peyton",
+    "last": "barber",
+    "position": "rb"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "cameron brate",
+    "first": "cameron",
+    "last": "brate",
+    "position": "te"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "kj brent",
+    "first": "kj",
+    "last": "brent",
+    "position": "wr"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "matthew eaton",
+    "first": "matthew",
+    "last": "eaton",
+    "position": "wr"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "andre ellington",
+    "first": "andre",
+    "last": "ellington",
+    "position": "rb"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "mike evans",
+    "first": "mike",
+    "last": "evans",
+    "position": "wr"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "nick fitzgerald",
+    "first": "nick",
+    "last": "fitzgerald",
     "position": "qb"
   },
   {
@@ -16842,74 +5954,10 @@
   {
     "team": "tampa bay buccaneers",
     "symbol": "TB",
-    "fullname": "ryan griffin",
-    "first": "ryan",
-    "last": "griffin",
-    "position": "qb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "nick fitzgerald",
-    "first": "nick",
-    "last": "fitzgerald",
-    "position": "qb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "peyton barber",
-    "first": "peyton",
-    "last": "barber",
-    "position": "rb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "ronald jones",
-    "first": "ronald",
-    "last": "jones",
-    "position": "rb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "andre ellington",
-    "first": "andre",
-    "last": "ellington",
-    "position": "rb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "dare ogunbowale",
-    "first": "dare",
-    "last": "ogunbowale",
-    "position": "rb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "bruce anderson",
-    "first": "bruce",
-    "last": "anderson",
-    "position": "rb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "fb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "mike evans",
-    "first": "mike",
-    "last": "evans",
-    "position": "wr"
+    "fullname": "matt gay",
+    "first": "matt",
+    "last": "gay",
+    "position": "k"
   },
   {
     "team": "tampa bay buccaneers",
@@ -16922,9 +5970,121 @@
   {
     "team": "tampa bay buccaneers",
     "symbol": "TB",
+    "fullname": "ryan griffin",
+    "first": "ryan",
+    "last": "griffin",
+    "position": "qb"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "oj howard",
+    "first": "oj",
+    "last": "howard",
+    "position": "te"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "tanner hudson",
+    "first": "tanner",
+    "last": "hudson",
+    "position": "te"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "anthony johnson",
+    "first": "anthony",
+    "last": "johnson",
+    "position": "wr"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "ronald jones ii",
+    "first": "ronald",
+    "last": "jones ii",
+    "position": "rb"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "jordan leggett",
+    "first": "jordan",
+    "last": "leggett",
+    "position": "te"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "damarkus lodge",
+    "first": "damarkus",
+    "last": "lodge",
+    "position": "wr"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "scott miller",
+    "first": "scott",
+    "last": "miller",
+    "position": "wr"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "bryant mitchell",
+    "first": "bryant",
+    "last": "mitchell",
+    "position": "wr"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "dare ogunbowale",
+    "first": "dare",
+    "last": "ogunbowale",
+    "position": "rb"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "scott orndoff",
+    "first": "scott",
+    "last": "orndoff",
+    "position": "te"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
     "fullname": "breshad perriman",
     "first": "breshad",
     "last": "perriman",
+    "position": "wr"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "cairo santos",
+    "first": "cairo",
+    "last": "santos",
+    "position": "k"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "spencer schnell",
+    "first": "spencer",
+    "last": "schnell",
+    "position": "wr"
+  },
+  {
+    "team": "tampa bay buccaneers",
+    "symbol": "TB",
+    "fullname": "cortrelle simpson",
+    "first": "cortrelle",
+    "last": "simpson",
     "position": "wr"
   },
   {
@@ -16946,745 +6106,17 @@
   {
     "team": "tampa bay buccaneers",
     "symbol": "TB",
-    "fullname": "scott miller",
-    "first": "scott",
-    "last": "miller",
-    "position": "wr"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "k.j. brent",
-    "first": "k.j.",
-    "last": "brent",
-    "position": "wr"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "anthony johnson",
-    "first": "anthony",
-    "last": "johnson",
-    "position": "wr"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "damarkus lodge",
-    "first": "damarkus",
-    "last": "lodge",
-    "position": "wr"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "cortrelle simpson",
-    "first": "cortrelle",
-    "last": "simpson",
-    "position": "wr"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "spencer schnell",
-    "first": "spencer",
-    "last": "schnell",
-    "position": "wr"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "bryant mitchell",
-    "first": "bryant",
-    "last": "mitchell",
-    "position": "wr"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "xavier ubosi",
-    "first": "xavier",
-    "last": "ubosi",
-    "position": "wr"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "o.j. howard",
-    "first": "o.j.",
-    "last": "howard",
-    "position": "te"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "cameron brate",
-    "first": "cameron",
-    "last": "brate",
-    "position": "te"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "antony auclair",
-    "first": "antony",
-    "last": "auclair",
-    "position": "te"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "jordan leggett",
-    "first": "jordan",
-    "last": "leggett",
-    "position": "te"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "tanner hudson",
-    "first": "tanner",
-    "last": "hudson",
-    "position": "te"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "donnie ernsberger",
-    "first": "donnie",
-    "last": "ernsberger",
-    "position": "te"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "donovan smith",
-    "first": "donovan",
-    "last": "smith",
-    "position": "lt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "michael liedtke",
-    "first": "michael",
-    "last": "liedtke",
-    "position": "lt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "cole boozer",
-    "first": "cole",
-    "last": "boozer",
-    "position": "lt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "ali marpet",
-    "first": "ali",
-    "last": "marpet",
-    "position": "lg"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "earl watford",
-    "first": "earl",
-    "last": "watford",
-    "position": "lg"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "zack bailey",
-    "first": "zack",
-    "last": "bailey",
-    "position": "lg"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "ryan jensen",
-    "first": "ryan",
-    "last": "jensen",
-    "position": "c"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "nate trewyn",
-    "first": "nate",
-    "last": "trewyn",
-    "position": "c"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "nate trewyn",
-    "first": "nate",
-    "last": "trewyn",
-    "position": "c"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "caleb benenoch",
-    "first": "caleb",
-    "last": "benenoch",
-    "position": "rg"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "alex cappa",
-    "first": "alex",
-    "last": "cappa",
-    "position": "rg"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "josh leribeus",
-    "first": "josh",
-    "last": "leribeus",
-    "position": "rg"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "demar dotson",
-    "first": "demar",
-    "last": "dotson",
-    "position": "rt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "ruben holcomb",
-    "first": "ruben",
-    "last": "holcomb",
-    "position": "rt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "rakeem nunez-roches",
-    "first": "rakeem",
-    "last": "nunez-roches",
-    "position": "lde"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "demone harris",
-    "first": "demone",
-    "last": "harris",
-    "position": "lde"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "kahzin daniels",
-    "first": "kahzin",
-    "last": "daniels",
-    "position": "lde"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "ndamukong suh",
-    "first": "ndamukong",
-    "last": "suh",
-    "position": "ndt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "vita vea",
-    "first": "vita",
-    "last": "vea",
-    "position": "ndt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "beau allen",
-    "first": "beau",
-    "last": "allen",
-    "position": "ndt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "terry beckner",
-    "first": "terry",
-    "last": "beckner",
-    "position": "ndt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "william gholston",
-    "first": "william",
-    "last": "gholston",
-    "position": "rde"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "anthony nelson",
-    "first": "anthony",
-    "last": "nelson",
-    "position": "rde"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "pat o'connor",
-    "first": "pat",
-    "last": "o'connor",
-    "position": "rde"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "david kenney",
-    "first": "david",
-    "last": "kenney",
-    "position": "rde"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "shaquil barrett",
-    "first": "shaquil",
-    "last": "barrett",
-    "position": "slb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "noah spence",
-    "first": "noah",
-    "last": "spence",
-    "position": "slb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "farrington huguenin",
-    "first": "farrington",
-    "last": "huguenin",
-    "position": "slb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "jason pierre-paul",
-    "first": "jason",
-    "last": "pierre-paul",
-    "position": "wlb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "carl nassib",
-    "first": "carl",
-    "last": "nassib",
-    "position": "wlb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "devante bond",
-    "first": "devante",
-    "last": "bond",
-    "position": "wlb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "dare odeyingbo",
-    "first": "dare",
-    "last": "odeyingbo",
-    "position": "wlb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "vernon iii hargreaves",
-    "first": "vernon",
-    "last": "iii",
-    "position": "rcb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "jamel dean",
-    "first": "jamel",
-    "last": "dean",
-    "position": "rcb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "ryan smith",
-    "first": "ryan",
-    "last": "smith",
-    "position": "rcb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "jalen allison",
-    "first": "jalen",
-    "last": "allison",
-    "position": "rcb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "carlton davis",
-    "first": "carlton",
-    "last": "davis",
-    "position": "lcb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "sean bunting",
-    "first": "sean",
-    "last": "bunting",
-    "position": "lcb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "de'vante harris",
-    "first": "de'vante",
-    "last": "harris",
-    "position": "lcb"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "justin evans",
-    "first": "justin",
-    "last": "evans",
-    "position": "ss"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "mike edwards",
-    "first": "mike",
-    "last": "edwards",
-    "position": "ss"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "kentrell brice",
-    "first": "kentrell",
-    "last": "brice",
-    "position": "ss"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "jordan whitehead",
-    "first": "jordan",
-    "last": "whitehead",
-    "position": "fs"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "m.j. stewart",
-    "first": "m.j.",
-    "last": "stewart",
-    "position": "fs"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "isaiah johnson",
-    "first": "isaiah",
-    "last": "johnson",
-    "position": "fs"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "lukas denis",
-    "first": "lukas",
-    "last": "denis",
-    "position": "fs"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "d'cota dixon",
-    "first": "d'cota",
-    "last": "dixon",
-    "position": "fs"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "bradley pinion",
-    "first": "bradley",
-    "last": "pinion",
-    "position": "p"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "zach triner",
-    "first": "zach",
-    "last": "triner",
-    "position": "ls"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "ryan griffin",
-    "first": "ryan",
-    "last": "griffin",
-    "position": "h"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "matt gay",
-    "first": "matt",
-    "last": "gay",
-    "position": "k"
-  },
-  {
-    "team": "tampa bay buccaneers",
-    "symbol": "TB",
-    "fullname": "cairo santos",
-    "first": "cairo",
-    "last": "santos",
-    "position": "k"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "deshaun watson",
-    "first": "deshaun",
-    "last": "watson",
+    "fullname": "jameis winston",
+    "first": "jameis",
+    "last": "winston",
     "position": "qb"
   },
   {
     "team": "houston texans",
     "symbol": "HOU",
-    "fullname": "aj mccarron",
-    "first": "aj",
-    "last": "mccarron",
-    "position": "qb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "joe webb",
-    "first": "joe",
-    "last": "webb",
-    "position": "qb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "lamar miller",
-    "first": "lamar",
-    "last": "miller",
-    "position": "rb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "d'onta foreman",
-    "first": "d'onta",
-    "last": "foreman",
-    "position": "rb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "josh ferguson",
-    "first": "josh",
-    "last": "ferguson",
-    "position": "rb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "buddy howell",
-    "first": "buddy",
-    "last": "howell",
-    "position": "rb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "taiwan jones",
-    "first": "taiwan",
-    "last": "jones",
-    "position": "rb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "karan higdon",
-    "first": "karan",
-    "last": "higdon",
-    "position": "rb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "damarea crockett",
-    "first": "damarea",
-    "last": "crockett",
-    "position": "rb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "cullen gillaspia",
-    "first": "cullen",
-    "last": "gillaspia",
-    "position": "fb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "deandre hopkins",
-    "first": "deandre",
-    "last": "hopkins",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "will fuller",
-    "first": "will",
-    "last": "fuller",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "keke coutee",
-    "first": "keke",
-    "last": "coutee",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "deandre carter",
-    "first": "deandre",
-    "last": "carter",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "vyncint smith",
-    "first": "vyncint",
-    "last": "smith",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "jester weah",
-    "first": "jester",
-    "last": "weah",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "steven mitchell",
-    "first": "steven",
-    "last": "mitchell",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "isaac whitney",
-    "first": "isaac",
-    "last": "whitney",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "tyron johnson",
-    "first": "tyron",
-    "last": "johnson",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "stephen louis",
-    "first": "stephen",
-    "last": "louis",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "johnnie dixon",
-    "first": "johnnie",
-    "last": "dixon",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "floyd allen",
-    "first": "floyd",
-    "last": "allen",
-    "position": "wr"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "jordan thomas",
-    "first": "jordan",
-    "last": "thomas",
+    "fullname": "jerell adams",
+    "first": "jerell",
+    "last": "adams",
     "position": "te"
   },
   {
@@ -17698,10 +6130,50 @@
   {
     "team": "houston texans",
     "symbol": "HOU",
-    "fullname": "kahale warring",
-    "first": "kahale",
-    "last": "warring",
-    "position": "te"
+    "fullname": "floyd allen",
+    "first": "floyd",
+    "last": "allen",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "deandre carter",
+    "first": "deandre",
+    "last": "carter",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "keke coutee",
+    "first": "keke",
+    "last": "coutee",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "damarea crockett",
+    "first": "damarea",
+    "last": "crockett",
+    "position": "rb"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "johnnie dixon",
+    "first": "johnnie",
+    "last": "dixon",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "ka'imi fairbairn",
+    "first": "ka'imi",
+    "last": "fairbairn",
+    "position": "k"
   },
   {
     "team": "houston texans",
@@ -17714,490 +6186,178 @@
   {
     "team": "houston texans",
     "symbol": "HOU",
-    "fullname": "jerell adams",
-    "first": "jerell",
-    "last": "adams",
+    "fullname": "josh ferguson",
+    "first": "josh",
+    "last": "ferguson",
+    "position": "rb"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "will fuller",
+    "first": "will",
+    "last": "fuller",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "cullen gillaspia",
+    "first": "cullen",
+    "last": "gillaspia",
+    "position": "rb"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "chad hansen",
+    "first": "chad",
+    "last": "hansen",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "karan higdon",
+    "first": "karan",
+    "last": "higdon",
+    "position": "rb"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "deandre hopkins",
+    "first": "deandre",
+    "last": "hopkins",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "buddy howell",
+    "first": "buddy",
+    "last": "howell",
+    "position": "rb"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "duke johnson",
+    "first": "duke",
+    "last": "johnson",
+    "position": "rb"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "tyron johnson",
+    "first": "tyron",
+    "last": "johnson",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "taiwan jones",
+    "first": "taiwan",
+    "last": "jones",
+    "position": "rb"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "stephen louis",
+    "first": "stephen",
+    "last": "louis",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "aj mccarron",
+    "first": "aj",
+    "last": "mccarron",
+    "position": "qb"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "lamar miller",
+    "first": "lamar",
+    "last": "miller",
+    "position": "rb"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "steven mitchell jr.",
+    "first": "steven",
+    "last": "mitchell jr.",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "vyncint smith",
+    "first": "vyncint",
+    "last": "smith",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "jordan ta'amu",
+    "first": "jordan",
+    "last": "ta'amu",
+    "position": "qb"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "jordan thomas",
+    "first": "jordan",
+    "last": "thomas",
     "position": "te"
   },
   {
     "team": "houston texans",
     "symbol": "HOU",
-    "fullname": "julie'n davenport",
-    "first": "julie'n",
-    "last": "davenport",
-    "position": "lt"
+    "fullname": "kahale warring",
+    "first": "kahale",
+    "last": "warring",
+    "position": "te"
   },
   {
     "team": "houston texans",
     "symbol": "HOU",
-    "fullname": "matt kalil",
-    "first": "matt",
-    "last": "kalil",
-    "position": "lt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "rick leonard",
-    "first": "rick",
-    "last": "leonard",
-    "position": "lt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "d.j. coker",
-    "first": "d.j.",
-    "last": "coker",
-    "position": "lt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "senio kelemete",
-    "first": "senio",
-    "last": "kelemete",
-    "position": "lg"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "martinas rankin",
-    "first": "martinas",
-    "last": "rankin",
-    "position": "lg"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "nick martin",
-    "first": "nick",
-    "last": "martin",
-    "position": "c"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "greg mancz",
-    "first": "greg",
-    "last": "mancz",
-    "position": "c"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "zach fulton",
-    "first": "zach",
-    "last": "fulton",
-    "position": "rg"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "max scharping",
-    "first": "max",
-    "last": "scharping",
-    "position": "rg"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "maurquice shakir",
-    "first": "maurquice",
-    "last": "shakir",
-    "position": "rg"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "seantrel henderson",
-    "first": "seantrel",
-    "last": "henderson",
-    "position": "rt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "tytus howard",
-    "first": "tytus",
-    "last": "howard",
-    "position": "rt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "roderick johnson",
-    "first": "roderick",
-    "last": "johnson",
-    "position": "rt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "j.j. watt",
-    "first": "j.j.",
-    "last": "watt",
-    "position": "lde"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "carlos watkins",
-    "first": "carlos",
-    "last": "watkins",
-    "position": "lde"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "joel heath",
-    "first": "joel",
-    "last": "heath",
-    "position": "lde"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "brandon dunn",
-    "first": "brandon",
-    "last": "dunn",
-    "position": "ndt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "albert huggins",
-    "first": "albert",
-    "last": "huggins",
-    "position": "ndt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "javier edwards",
-    "first": "javier",
-    "last": "edwards",
-    "position": "ndt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "walter palmore",
-    "first": "walter",
-    "last": "palmore",
-    "position": "ndt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "ira savage-lewis",
-    "first": "ira",
-    "last": "savage-lewis",
-    "position": "ndt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "d.j. reader",
-    "first": "d.j.",
-    "last": "reader",
-    "position": "rde"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "angelo blackson",
-    "first": "angelo",
-    "last": "blackson",
-    "position": "rde"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "charles omenihu",
-    "first": "charles",
-    "last": "omenihu",
-    "position": "rde"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "johnny dwight",
-    "first": "johnny",
-    "last": "dwight",
-    "position": "rde"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "jadeveon clowney",
-    "first": "jadeveon",
-    "last": "clowney",
-    "position": "slb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "brennan scarlett",
-    "first": "brennan",
-    "last": "scarlett",
-    "position": "slb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "jamal davis",
-    "first": "jamal",
-    "last": "davis",
-    "position": "slb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "duke ejiofor",
-    "first": "duke",
-    "last": "ejiofor",
-    "position": "slb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "whitney mercilus",
-    "first": "whitney",
-    "last": "mercilus",
-    "position": "wlb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "davin bellamy",
-    "first": "davin",
-    "last": "bellamy",
-    "position": "wlb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "chris landrum",
-    "first": "chris",
-    "last": "landrum",
-    "position": "wlb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "bradley roby",
-    "first": "bradley",
-    "last": "roby",
-    "position": "rcb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "lonnie johnson",
-    "first": "lonnie",
-    "last": "johnson",
-    "position": "rcb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "jermaine kelly",
-    "first": "jermaine",
-    "last": "kelly",
-    "position": "rcb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "derrick baity",
-    "first": "derrick",
-    "last": "baity",
-    "position": "rcb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "johnathan joseph",
-    "first": "johnathan",
-    "last": "joseph",
-    "position": "lcb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "aaron colvin",
-    "first": "aaron",
-    "last": "colvin",
-    "position": "lcb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "johnson bademosi",
-    "first": "johnson",
-    "last": "bademosi",
-    "position": "lcb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "xavier crawford",
-    "first": "xavier",
-    "last": "crawford",
-    "position": "lcb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "deante burton",
-    "first": "deante",
-    "last": "burton",
-    "position": "lcb"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "tashaun gipson",
-    "first": "tashaun",
-    "last": "gipson",
-    "position": "ss"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "briean boddy-calhoun",
-    "first": "briean",
-    "last": "boddy-calhoun",
-    "position": "ss"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "a.j. hendy",
-    "first": "a.j.",
-    "last": "hendy",
-    "position": "ss"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "chris johnson",
-    "first": "chris",
-    "last": "johnson",
-    "position": "ss"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "justin reid",
-    "first": "justin",
-    "last": "reid",
-    "position": "fs"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "jahleel addae",
-    "first": "jahleel",
-    "last": "addae",
-    "position": "fs"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "a.j. moore",
-    "first": "a.j.",
-    "last": "moore",
-    "position": "fs"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "austin exford",
-    "first": "austin",
-    "last": "exford",
-    "position": "fs"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "trevor daniel",
-    "first": "trevor",
-    "last": "daniel",
-    "position": "p"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "jon weeks",
-    "first": "jon",
-    "last": "weeks",
-    "position": "ls"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "trevor daniel",
-    "first": "trevor",
-    "last": "daniel",
-    "position": "h"
-  },
-  {
-    "team": "houston texans",
-    "symbol": "HOU",
-    "fullname": "ka'imi fairbairn",
-    "first": "ka'imi",
-    "last": "fairbairn",
-    "position": "k"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "cam newton",
-    "first": "cam",
-    "last": "newton",
+    "fullname": "deshaun watson",
+    "first": "deshaun",
+    "last": "watson",
     "position": "qb"
   },
   {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "taylor heinicke",
-    "first": "taylor",
-    "last": "heinicke",
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "jester weah",
+    "first": "jester",
+    "last": "weah",
+    "position": "wr"
+  },
+  {
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "joe webb",
+    "first": "joe",
+    "last": "webb",
     "position": "qb"
   },
   {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "will grier",
-    "first": "will",
-    "last": "grier",
-    "position": "qb"
+    "team": "houston texans",
+    "symbol": "HOU",
+    "fullname": "isaac whitney",
+    "first": "isaac",
+    "last": "whitney",
+    "position": "wr"
   },
   {
     "team": "carolina panthers",
@@ -18210,17 +6370,9 @@
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "christian mccaffrey",
-    "first": "christian",
-    "last": "mccaffrey",
-    "position": "rb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "jordan scarlett",
-    "first": "jordan",
-    "last": "scarlett",
+    "fullname": "alex armah",
+    "first": "alex",
+    "last": "armah",
     "position": "rb"
   },
   {
@@ -18234,18 +6386,10 @@
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "elijah holyfield",
-    "first": "elijah",
-    "last": "holyfield",
-    "position": "rb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "elijah hood",
-    "first": "elijah",
-    "last": "hood",
-    "position": "rb"
+    "fullname": "marcus baugh",
+    "first": "marcus",
+    "last": "baugh",
+    "position": "te"
   },
   {
     "team": "carolina panthers",
@@ -18258,34 +6402,42 @@
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "alex armah",
-    "first": "alex",
-    "last": "armah",
-    "position": "fb"
+    "fullname": "graham gano",
+    "first": "graham",
+    "last": "gano",
+    "position": "k"
   },
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "d.j. moore",
-    "first": "d.j.",
-    "last": "moore",
+    "fullname": "terry godwin",
+    "first": "terry",
+    "last": "godwin",
     "position": "wr"
   },
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "curtis samuel",
-    "first": "curtis",
-    "last": "samuel",
-    "position": "wr"
+    "fullname": "will grier",
+    "first": "will",
+    "last": "grier",
+    "position": "qb"
   },
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "jarius wright",
-    "first": "jarius",
-    "last": "wright",
-    "position": "wr"
+    "fullname": "taylor heinicke",
+    "first": "taylor",
+    "last": "heinicke",
+    "position": "qb"
+  },
+  {
+    "team": "carolina panthers",
+    "symbol": "CAR",
+    "fullname": "temarrick hemingway",
+    "first": "temarrick",
+    "last": "hemingway",
+    "position": "te"
   },
   {
     "team": "carolina panthers",
@@ -18298,10 +6450,82 @@
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "torrey smith",
-    "first": "torrey",
-    "last": "smith",
+    "fullname": "elijah holyfield",
+    "first": "elijah",
+    "last": "holyfield",
+    "position": "rb"
+  },
+  {
+    "team": "carolina panthers",
+    "symbol": "CAR",
+    "fullname": "cole hunt",
+    "first": "cole",
+    "last": "hunt",
+    "position": "te"
+  },
+  {
+    "team": "carolina panthers",
+    "symbol": "CAR",
+    "fullname": "damion jeanpiere jr.",
+    "first": "damion",
+    "last": "jeanpiere jr.",
     "position": "wr"
+  },
+  {
+    "team": "carolina panthers",
+    "symbol": "CAR",
+    "fullname": "andre levrone",
+    "first": "andre",
+    "last": "levrone",
+    "position": "wr"
+  },
+  {
+    "team": "carolina panthers",
+    "symbol": "CAR",
+    "fullname": "chris manhertz",
+    "first": "chris",
+    "last": "manhertz",
+    "position": "te"
+  },
+  {
+    "team": "carolina panthers",
+    "symbol": "CAR",
+    "fullname": "christian mccaffrey",
+    "first": "christian",
+    "last": "mccaffrey",
+    "position": "rb"
+  },
+  {
+    "team": "carolina panthers",
+    "symbol": "CAR",
+    "fullname": "jaydon mickens",
+    "first": "jaydon",
+    "last": "mickens",
+    "position": "wr"
+  },
+  {
+    "team": "carolina panthers",
+    "symbol": "CAR",
+    "fullname": "dj moore",
+    "first": "dj",
+    "last": "moore",
+    "position": "wr"
+  },
+  {
+    "team": "carolina panthers",
+    "symbol": "CAR",
+    "fullname": "cam newton",
+    "first": "cam",
+    "last": "newton",
+    "position": "qb"
+  },
+  {
+    "team": "carolina panthers",
+    "symbol": "CAR",
+    "fullname": "greg olsen",
+    "first": "greg",
+    "last": "olsen",
+    "position": "te"
   },
   {
     "team": "carolina panthers",
@@ -18322,42 +6546,34 @@
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "terry godwin",
-    "first": "terry",
-    "last": "godwin",
+    "fullname": "curtis samuel",
+    "first": "curtis",
+    "last": "samuel",
     "position": "wr"
   },
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "deandrew white",
-    "first": "deandrew",
-    "last": "white",
-    "position": "wr"
+    "fullname": "jordan scarlett",
+    "first": "jordan",
+    "last": "scarlett",
+    "position": "rb"
   },
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "andre levrone",
-    "first": "andre",
-    "last": "levrone",
-    "position": "wr"
+    "fullname": "joey slye",
+    "first": "joey",
+    "last": "slye",
+    "position": "k"
   },
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "damion jeanpiere",
-    "first": "damion",
-    "last": "jeanpiere",
+    "fullname": "torrey smith",
+    "first": "torrey",
+    "last": "smith",
     "position": "wr"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "greg olsen",
-    "first": "greg",
-    "last": "olsen",
-    "position": "te"
   },
   {
     "team": "carolina panthers",
@@ -18370,538 +6586,42 @@
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "chris manhertz",
-    "first": "chris",
-    "last": "manhertz",
-    "position": "te"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
     "fullname": "jason vander laan",
     "first": "jason",
-    "last": "vander",
+    "last": "vander laan",
     "position": "te"
   },
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "marcus baugh",
-    "first": "marcus",
-    "last": "baugh",
-    "position": "te"
+    "fullname": "deandrew white",
+    "first": "deandrew",
+    "last": "white",
+    "position": "wr"
   },
   {
     "team": "carolina panthers",
     "symbol": "CAR",
-    "fullname": "cole hunt",
-    "first": "cole",
-    "last": "hunt",
-    "position": "te"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "ethan wolf",
-    "first": "ethan",
-    "last": "wolf",
-    "position": "te"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "temarrick hemingway",
-    "first": "temarrick",
-    "last": "hemingway",
-    "position": "te"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "taylor moton",
-    "first": "taylor",
-    "last": "moton",
-    "position": "lt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "greg little",
-    "first": "greg",
-    "last": "little",
-    "position": "lt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "dillon gordon",
-    "first": "dillon",
-    "last": "gordon",
-    "position": "lt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "greg van roten",
-    "first": "greg",
-    "last": "van",
-    "position": "lg"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "taylor hearn",
-    "first": "taylor",
-    "last": "hearn",
-    "position": "lg"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "matt paradis",
-    "first": "matt",
-    "last": "paradis",
-    "position": "c"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "tyler larsen",
-    "first": "tyler",
-    "last": "larsen",
-    "position": "c"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "parker collins",
-    "first": "parker",
-    "last": "collins",
-    "position": "c"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "trai turner",
-    "first": "trai",
-    "last": "turner",
-    "position": "rg"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "dorian johnson",
-    "first": "dorian",
-    "last": "johnson",
-    "position": "rg"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "kofi amichia",
-    "first": "kofi",
-    "last": "amichia",
-    "position": "rg"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "daryl williams",
-    "first": "daryl",
-    "last": "williams",
-    "position": "rt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "ian silberman",
-    "first": "ian",
-    "last": "silberman",
-    "position": "rt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "dennis daley",
-    "first": "dennis",
-    "last": "daley",
-    "position": "rt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "kitt o'brien",
-    "first": "kitt",
-    "last": "o'brien",
-    "position": "rt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "gerald mccoy",
-    "first": "gerald",
-    "last": "mccoy",
-    "position": "lde"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "bryan cox",
-    "first": "bryan",
-    "last": "cox",
-    "position": "lde"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "destiny vaeao",
-    "first": "destiny",
-    "last": "vaeao",
-    "position": "lde"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "dontari poe",
-    "first": "dontari",
-    "last": "poe",
-    "position": "ndt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "vernon butler",
-    "first": "vernon",
-    "last": "butler",
-    "position": "ndt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "elijah qualls",
-    "first": "elijah",
-    "last": "qualls",
-    "position": "ndt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "kawann short",
-    "first": "kawann",
-    "last": "short",
-    "position": "rde"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "kyle love",
-    "first": "kyle",
-    "last": "love",
-    "position": "rde"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "woodrow hamilton",
-    "first": "woodrow",
-    "last": "hamilton",
-    "position": "rde"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "mario addison",
-    "first": "mario",
-    "last": "addison",
-    "position": "slb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "christian miller",
-    "first": "christian",
-    "last": "miller",
-    "position": "slb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "marquis haynes",
-    "first": "marquis",
-    "last": "haynes",
-    "position": "slb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "efe obada",
-    "first": "efe",
-    "last": "obada",
-    "position": "slb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "brian burns",
-    "first": "brian",
-    "last": "burns",
-    "position": "wlb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "bruce irvin",
-    "first": "bruce",
-    "last": "irvin",
-    "position": "wlb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "sione teuhema",
-    "first": "sione",
-    "last": "teuhema",
-    "position": "wlb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "antwione williams",
-    "first": "antwione",
-    "last": "williams",
-    "position": "wlb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "donte jackson",
-    "first": "donte",
-    "last": "jackson",
-    "position": "rcb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "corn elder",
-    "first": "corn",
-    "last": "elder",
-    "position": "rcb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "javien elliott",
-    "first": "javien",
-    "last": "elliott",
-    "position": "rcb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "kevon seymour",
-    "first": "kevon",
-    "last": "seymour",
-    "position": "rcb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "josh thornton",
-    "first": "josh",
-    "last": "thornton",
-    "position": "rcb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "james bradberry",
-    "first": "james",
-    "last": "bradberry",
-    "position": "lcb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "lorenzo doss",
-    "first": "lorenzo",
-    "last": "doss",
-    "position": "lcb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "ross cockrell",
-    "first": "ross",
-    "last": "cockrell",
-    "position": "lcb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "cole luke",
-    "first": "cole",
-    "last": "luke",
-    "position": "lcb"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "eric reid",
-    "first": "eric",
-    "last": "reid",
-    "position": "ss"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "colin jones",
-    "first": "colin",
-    "last": "jones",
-    "position": "ss"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "damian parms",
-    "first": "damian",
-    "last": "parms",
-    "position": "ss"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "kai nacua",
-    "first": "kai",
-    "last": "nacua",
-    "position": "ss"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "rashaan gaulden",
-    "first": "rashaan",
-    "last": "gaulden",
-    "position": "fs"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "quin blanding",
-    "first": "quin",
-    "last": "blanding",
-    "position": "fs"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "corrion ballard",
-    "first": "corrion",
-    "last": "ballard",
-    "position": "fs"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "michael palardy",
-    "first": "michael",
-    "last": "palardy",
-    "position": "p"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "j.j. jansen",
-    "first": "j.j.",
-    "last": "jansen",
-    "position": "ls"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "michael palardy",
-    "first": "michael",
-    "last": "palardy",
-    "position": "h"
-  },
-  {
-    "team": "carolina panthers",
-    "symbol": "CAR",
-    "fullname": "graham gano",
-    "first": "graham",
-    "last": "gano",
-    "position": "k"
+    "fullname": "jarius wright",
+    "first": "jarius",
+    "last": "wright",
+    "position": "wr"
   },
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "jimmy garoppolo",
-    "first": "jimmy",
-    "last": "garoppolo",
-    "position": "qb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "nick mullens",
-    "first": "nick",
-    "last": "mullens",
-    "position": "qb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "c.j. beathard",
-    "first": "c.j.",
+    "fullname": "cj beathard",
+    "first": "cj",
     "last": "beathard",
     "position": "qb"
   },
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "wilton speight",
-    "first": "wilton",
-    "last": "speight",
-    "position": "qb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "tevin coleman",
-    "first": "tevin",
-    "last": "coleman",
-    "position": "rb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "jerick mckinnon",
-    "first": "jerick",
-    "last": "mckinnon",
-    "position": "rb"
+    "fullname": "kendrick bourne",
+    "first": "kendrick",
+    "last": "bourne",
+    "position": "wr"
   },
   {
     "team": "san francisco 49ers",
@@ -18914,42 +6634,34 @@
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "raheem mostert",
-    "first": "raheem",
-    "last": "mostert",
+    "fullname": "garrett celek",
+    "first": "garrett",
+    "last": "celek",
+    "position": "te"
+  },
+  {
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "tevin coleman",
+    "first": "tevin",
+    "last": "coleman",
     "position": "rb"
   },
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "jeff wilson",
-    "first": "jeff",
-    "last": "wilson",
-    "position": "rb"
+    "fullname": "ross dwelley",
+    "first": "ross",
+    "last": "dwelley",
+    "position": "te"
   },
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "austin walter",
-    "first": "austin",
-    "last": "walter",
-    "position": "rb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "kyle juszczyk",
-    "first": "kyle",
-    "last": "juszczyk",
-    "position": "fb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "dante pettis",
-    "first": "dante",
-    "last": "pettis",
-    "position": "wr"
+    "fullname": "jimmy garoppolo",
+    "first": "jimmy",
+    "last": "garoppolo",
+    "position": "qb"
   },
   {
     "team": "san francisco 49ers",
@@ -18962,25 +6674,25 @@
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "deebo samuel",
-    "first": "deebo",
-    "last": "samuel",
-    "position": "wr"
+    "fullname": "robbie gould",
+    "first": "robbie",
+    "last": "gould",
+    "position": "k"
   },
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "trent taylor",
-    "first": "trent",
-    "last": "taylor",
-    "position": "wr"
+    "fullname": "daniel helm",
+    "first": "daniel",
+    "last": "helm",
+    "position": "te"
   },
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "jordan matthews",
-    "first": "jordan",
-    "last": "matthews",
+    "fullname": "malik henry",
+    "first": "malik",
+    "last": "henry",
     "position": "wr"
   },
   {
@@ -18994,14 +6706,6 @@
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "kendrick bourne",
-    "first": "kendrick",
-    "last": "bourne",
-    "position": "wr"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
     "fullname": "richie james",
     "first": "richie",
     "last": "james",
@@ -19010,9 +6714,65 @@
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "max mccaffrey",
-    "first": "max",
-    "last": "mccaffrey",
+    "fullname": "kyle juszczyk",
+    "first": "kyle",
+    "last": "juszczyk",
+    "position": "fb"
+  },
+  {
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "george kittle",
+    "first": "george",
+    "last": "kittle",
+    "position": "te"
+  },
+  {
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "jordan matthews",
+    "first": "jordan",
+    "last": "matthews",
+    "position": "wr"
+  },
+  {
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "tyree mayfield",
+    "first": "tyree",
+    "last": "mayfield",
+    "position": "te"
+  },
+  {
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "jerick mckinnon",
+    "first": "jerick",
+    "last": "mckinnon",
+    "position": "rb"
+  },
+  {
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "raheem mostert",
+    "first": "raheem",
+    "last": "mostert",
+    "position": "rb"
+  },
+  {
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "nick mullens",
+    "first": "nick",
+    "last": "mullens",
+    "position": "qb"
+  },
+  {
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "dante pettis",
+    "first": "dante",
+    "last": "pettis",
     "position": "wr"
   },
   {
@@ -19026,34 +6786,10 @@
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "malik henry",
-    "first": "malik",
-    "last": "henry",
+    "fullname": "deebo samuel",
+    "first": "deebo",
+    "last": "samuel",
     "position": "wr"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "george kittle",
-    "first": "george",
-    "last": "kittle",
-    "position": "te"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "garrett celek",
-    "first": "garrett",
-    "last": "celek",
-    "position": "te"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "levine toilolo",
-    "first": "levine",
-    "last": "toilolo",
-    "position": "te"
   },
   {
     "team": "san francisco 49ers",
@@ -19066,730 +6802,42 @@
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "ross dwelley",
-    "first": "ross",
-    "last": "dwelley",
-    "position": "te"
+    "fullname": "wilton speight",
+    "first": "wilton",
+    "last": "speight",
+    "position": "qb"
   },
   {
     "team": "san francisco 49ers",
     "symbol": "SF",
-    "fullname": "tyree mayfield",
-    "first": "tyree",
-    "last": "mayfield",
-    "position": "te"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "joe staley",
-    "first": "joe",
-    "last": "staley",
-    "position": "lt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "shon coleman",
-    "first": "shon",
-    "last": "coleman",
-    "position": "lt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "justin skule",
-    "first": "justin",
-    "last": "skule",
-    "position": "lt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "laken tomlinson",
-    "first": "laken",
-    "last": "tomlinson",
-    "position": "lg"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "ben garland",
-    "first": "ben",
-    "last": "garland",
-    "position": "lg"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "willie beavers",
-    "first": "willie",
-    "last": "beavers",
-    "position": "lg"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "weston richburg",
-    "first": "weston",
-    "last": "richburg",
-    "position": "c"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "erik magnuson",
-    "first": "erik",
-    "last": "magnuson",
-    "position": "c"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "erik magnuson",
-    "first": "erik",
-    "last": "magnuson",
-    "position": "c"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "wesley johnson",
-    "first": "wesley",
-    "last": "johnson",
-    "position": "c"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "mike person",
-    "first": "mike",
-    "last": "person",
-    "position": "rg"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "joshua garnett",
-    "first": "joshua",
-    "last": "garnett",
-    "position": "rg"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "willie beavers",
-    "first": "willie",
-    "last": "beavers",
-    "position": "rg"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "mike mcglinchey",
-    "first": "mike",
-    "last": "mcglinchey",
-    "position": "rt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "shon coleman",
-    "first": "shon",
-    "last": "coleman",
-    "position": "rt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "solomon thomas",
-    "first": "solomon",
-    "last": "thomas",
-    "position": "ldt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "d.j. jones",
-    "first": "d.j.",
-    "last": "jones",
-    "position": "ldt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "kapron lewis-moore",
-    "first": "kapron",
-    "last": "lewis-moore",
-    "position": "ldt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "kevin givens",
-    "first": "kevin",
-    "last": "givens",
-    "position": "ldt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "nick bosa",
-    "first": "nick",
-    "last": "bosa",
-    "position": "lde"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "arik armstead",
-    "first": "arik",
-    "last": "armstead",
-    "position": "lde"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "jullian taylor",
-    "first": "jullian",
+    "fullname": "trent taylor",
+    "first": "trent",
     "last": "taylor",
-    "position": "lde"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "deforest buckner",
-    "first": "deforest",
-    "last": "buckner",
-    "position": "rdt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "sheldon day",
-    "first": "sheldon",
-    "last": "day",
-    "position": "rdt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "cedric thornton",
-    "first": "cedric",
-    "last": "thornton",
-    "position": "rdt"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "dee ford",
-    "first": "dee",
-    "last": "ford",
-    "position": "rde"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "ronald blair",
-    "first": "ronald",
-    "last": "blair",
-    "position": "rde"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "kentavius street",
-    "first": "kentavius",
-    "last": "street",
-    "position": "rde"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "jamell garcia-williams",
-    "first": "jamell",
-    "last": "garcia-williams",
-    "position": "rde"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "kwon alexander",
-    "first": "kwon",
-    "last": "alexander",
-    "position": "mlb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "elijah lee",
-    "first": "elijah",
-    "last": "lee",
-    "position": "mlb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "mark nzeocha",
-    "first": "mark",
-    "last": "nzeocha",
-    "position": "mlb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "dre greenlaw",
-    "first": "dre",
-    "last": "greenlaw",
-    "position": "slb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "malcolm smith",
-    "first": "malcolm",
-    "last": "smith",
-    "position": "slb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "david mayo",
-    "first": "david",
-    "last": "mayo",
-    "position": "slb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "fred warner",
-    "first": "fred",
-    "last": "warner",
-    "position": "wlb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "azeez al-shaair",
-    "first": "azeez",
-    "last": "al-shaair",
-    "position": "wlb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "laroy reynolds",
-    "first": "laroy",
-    "last": "reynolds",
-    "position": "wlb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "ahkello witherspoon",
-    "first": "ahkello",
-    "last": "witherspoon",
-    "position": "rcb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "jason verrett",
-    "first": "jason",
-    "last": "verrett",
-    "position": "rcb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "greg mabin",
-    "first": "greg",
-    "last": "mabin",
-    "position": "rcb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "marcell harris",
-    "first": "marcell",
-    "last": "harris",
-    "position": "rcb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "emmanuel moseley",
-    "first": "emmanuel",
-    "last": "moseley",
-    "position": "rcb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "richard sherman",
-    "first": "richard",
-    "last": "sherman",
-    "position": "lcb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "k'waun williams",
-    "first": "k'waun",
-    "last": "williams",
-    "position": "lcb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "tim harris",
-    "first": "tim",
-    "last": "harris",
-    "position": "lcb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "alex brown",
-    "first": "alex",
-    "last": "brown",
-    "position": "lcb"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "jaquiski tartt",
-    "first": "jaquiski",
-    "last": "tartt",
-    "position": "ss"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "marcell harris",
-    "first": "marcell",
-    "last": "harris",
-    "position": "ss"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "tyree robinson",
-    "first": "tyree",
-    "last": "robinson",
-    "position": "ss"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "demetrius flannigan-fowles",
-    "first": "demetrius",
-    "last": "flannigan-fowles",
-    "position": "ss"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "jimmie ward",
-    "first": "jimmie",
-    "last": "ward",
-    "position": "fs"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "adrian colbert",
-    "first": "adrian",
-    "last": "colbert",
-    "position": "fs"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "antone exum",
-    "first": "antone",
-    "last": "exum",
-    "position": "fs"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "tarvarius moore",
-    "first": "tarvarius",
-    "last": "moore",
-    "position": "fs"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "d.j. reed",
-    "first": "d.j.",
-    "last": "reed",
-    "position": "fs"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "mitch wishnowsky",
-    "first": "mitch",
-    "last": "wishnowsky",
-    "position": "p"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "colin holba",
-    "first": "colin",
-    "last": "holba",
-    "position": "ls"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "kyle nelson",
-    "first": "kyle",
-    "last": "nelson",
-    "position": "ls"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "mitch wishnowsky",
-    "first": "mitch",
-    "last": "wishnowsky",
-    "position": "h"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "robbie gould",
-    "first": "robbie",
-    "last": "gould",
-    "position": "k"
-  },
-  {
-    "team": "san francisco 49ers",
-    "symbol": "SF",
-    "fullname": "jon brown",
-    "first": "jon",
-    "last": "brown",
-    "position": "k"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "tom brady",
-    "first": "tom",
-    "last": "brady",
-    "position": "qb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "brian hoyer",
-    "first": "brian",
-    "last": "hoyer",
-    "position": "qb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "jarrett stidham",
-    "first": "jarrett",
-    "last": "stidham",
-    "position": "qb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "danny etling",
-    "first": "danny",
-    "last": "etling",
-    "position": "qb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "sony michel",
-    "first": "sony",
-    "last": "michel",
-    "position": "rb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "james white",
-    "first": "james",
-    "last": "white",
-    "position": "rb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "rex burkhead",
-    "first": "rex",
-    "last": "burkhead",
-    "position": "rb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "damien harris",
-    "first": "damien",
-    "last": "harris",
-    "position": "rb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "brandon bolden",
-    "first": "brandon",
-    "last": "bolden",
-    "position": "rb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "nick brossette",
-    "first": "nick",
-    "last": "brossette",
-    "position": "rb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "james develin",
-    "first": "james",
-    "last": "develin",
-    "position": "fb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "julian edelman",
-    "first": "julian",
-    "last": "edelman",
     "position": "wr"
   },
   {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "n'keal harry",
-    "first": "n'keal",
-    "last": "harry",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "phillip dorsett",
-    "first": "phillip",
-    "last": "dorsett",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "demaryius thomas",
-    "first": "demaryius",
-    "last": "thomas",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "maurice harris",
-    "first": "maurice",
-    "last": "harris",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "dontrelle inman",
-    "first": "dontrelle",
-    "last": "inman",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "braxton berrios",
-    "first": "braxton",
-    "last": "berrios",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "matthew slater",
-    "first": "matthew",
-    "last": "slater",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "damoun patterson",
-    "first": "damoun",
-    "last": "patterson",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "ryan davis",
-    "first": "ryan",
-    "last": "davis",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "jakobi meyers",
-    "first": "jakobi",
-    "last": "meyers",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "gunner olszewski",
-    "first": "gunner",
-    "last": "olszewski",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "josh gordon",
-    "first": "josh",
-    "last": "gordon",
-    "position": "wr"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "matt lacosse",
-    "first": "matt",
-    "last": "lacosse",
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "levine toilolo",
+    "first": "levine",
+    "last": "toilolo",
     "position": "te"
   },
   {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "benjamin watson",
-    "first": "benjamin",
-    "last": "watson",
-    "position": "te"
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "austin walter",
+    "first": "austin",
+    "last": "walter",
+    "position": "rb"
+  },
+  {
+    "team": "san francisco 49ers",
+    "symbol": "SF",
+    "fullname": "jeffery wilson",
+    "first": "jeffery",
+    "last": "wilson",
+    "position": "rb"
   },
   {
     "team": "new england patriots",
@@ -19797,14 +6845,6 @@
     "fullname": "stephen anderson",
     "first": "stephen",
     "last": "anderson",
-    "position": "te"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "ryan izzo",
-    "first": "ryan",
-    "last": "izzo",
     "position": "te"
   },
   {
@@ -19818,498 +6858,82 @@
   {
     "team": "new england patriots",
     "symbol": "NE",
-    "fullname": "jakob johnson",
-    "first": "jakob",
-    "last": "johnson",
-    "position": "te"
+    "fullname": "braxton berrios",
+    "first": "braxton",
+    "last": "berrios",
+    "position": "wr"
   },
   {
     "team": "new england patriots",
     "symbol": "NE",
-    "fullname": "isaiah wynn",
-    "first": "isaiah",
-    "last": "wynn",
-    "position": "lt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "cole croston",
-    "first": "cole",
-    "last": "croston",
-    "position": "lt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "yodny cajuste",
-    "first": "yodny",
-    "last": "cajuste",
-    "position": "lt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "cedrick lang",
-    "first": "cedrick",
-    "last": "lang",
-    "position": "lt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "joe thuney",
-    "first": "joe",
-    "last": "thuney",
-    "position": "lg"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "ted karras",
-    "first": "ted",
-    "last": "karras",
-    "position": "lg"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "david andrews",
-    "first": "david",
-    "last": "andrews",
-    "position": "c"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "james ferentz",
-    "first": "james",
-    "last": "ferentz",
-    "position": "c"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "shaq mason",
-    "first": "shaq",
-    "last": "mason",
-    "position": "rg"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "brian schwenke",
-    "first": "brian",
-    "last": "schwenke",
-    "position": "rg"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "hjalte froholdt",
-    "first": "hjalte",
-    "last": "froholdt",
-    "position": "rg"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "marcus cannon",
-    "first": "marcus",
-    "last": "cannon",
-    "position": "rt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "dan skipper",
-    "first": "dan",
-    "last": "skipper",
-    "position": "rt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "cedrick lang",
-    "first": "cedrick",
-    "last": "lang",
-    "position": "rt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "lawrence guy",
-    "first": "lawrence",
-    "last": "guy",
-    "position": "ldt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "david parry",
-    "first": "david",
-    "last": "parry",
-    "position": "ldt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "byron cowart",
-    "first": "byron",
-    "last": "cowart",
-    "position": "ldt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "deatrich wise",
-    "first": "deatrich",
-    "last": "wise",
-    "position": "lde"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "chase winovich",
-    "first": "chase",
-    "last": "winovich",
-    "position": "lde"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "keionta davis",
-    "first": "keionta",
-    "last": "davis",
-    "position": "lde"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "ufomba kamalu",
-    "first": "ufomba",
-    "last": "kamalu",
-    "position": "lde"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "shilique calhoun",
-    "first": "shilique",
-    "last": "calhoun",
-    "position": "lde"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "mike pennel",
-    "first": "mike",
-    "last": "pennel",
-    "position": "rdt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "danny shelton",
-    "first": "danny",
-    "last": "shelton",
-    "position": "rdt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "adam butler",
-    "first": "adam",
-    "last": "butler",
-    "position": "rdt"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "michael bennett",
-    "first": "michael",
-    "last": "bennett",
-    "position": "rde"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "john simon",
-    "first": "john",
-    "last": "simon",
-    "position": "rde"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "derek rivers",
-    "first": "derek",
-    "last": "rivers",
-    "position": "rde"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "trent harris",
-    "first": "trent",
-    "last": "harris",
-    "position": "rde"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "nick thurman",
-    "first": "nick",
-    "last": "thurman",
-    "position": "rde"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "dont'a hightower",
-    "first": "dont'a",
-    "last": "hightower",
-    "position": "mlb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "elandon roberts",
-    "first": "elandon",
-    "last": "roberts",
-    "position": "mlb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "ja'whaun bentley",
-    "first": "ja'whaun",
-    "last": "bentley",
-    "position": "mlb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "kyle van noy",
-    "first": "kyle",
-    "last": "van",
-    "position": "slb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "christian sam",
-    "first": "christian",
-    "last": "sam",
-    "position": "slb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "terez hall",
-    "first": "terez",
-    "last": "hall",
-    "position": "slb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "jamie collins",
-    "first": "jamie",
-    "last": "collins",
-    "position": "wlb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "brandon king",
+    "fullname": "brandon bolden",
     "first": "brandon",
-    "last": "king",
-    "position": "wlb"
+    "last": "bolden",
+    "position": "rb"
   },
   {
     "team": "new england patriots",
     "symbol": "NE",
-    "fullname": "calvin munson",
-    "first": "calvin",
-    "last": "munson",
-    "position": "wlb"
+    "fullname": "tom brady",
+    "first": "tom",
+    "last": "brady",
+    "position": "qb"
   },
   {
     "team": "new england patriots",
     "symbol": "NE",
-    "fullname": "stephon gilmore",
-    "first": "stephon",
-    "last": "gilmore",
-    "position": "rcb"
+    "fullname": "nick brossette",
+    "first": "nick",
+    "last": "brossette",
+    "position": "rb"
   },
   {
     "team": "new england patriots",
     "symbol": "NE",
-    "fullname": "jonathan jones",
-    "first": "jonathan",
-    "last": "jones",
-    "position": "rcb"
+    "fullname": "rex burkhead",
+    "first": "rex",
+    "last": "burkhead",
+    "position": "rb"
   },
   {
     "team": "new england patriots",
     "symbol": "NE",
-    "fullname": "keion crossen",
-    "first": "keion",
-    "last": "crossen",
-    "position": "rcb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "ken webster",
-    "first": "ken",
-    "last": "webster",
-    "position": "rcb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "d'angelo ross",
-    "first": "d'angelo",
-    "last": "ross",
-    "position": "rcb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "jason mccourty",
-    "first": "jason",
-    "last": "mccourty",
-    "position": "lcb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "j.c. jackson",
-    "first": "j.c.",
-    "last": "jackson",
-    "position": "lcb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "joejuan williams",
-    "first": "joejuan",
-    "last": "williams",
-    "position": "lcb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "duke dawson",
-    "first": "duke",
-    "last": "dawson",
-    "position": "lcb"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "patrick chung",
-    "first": "patrick",
-    "last": "chung",
-    "position": "ss"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "obi melifonwu",
-    "first": "obi",
-    "last": "melifonwu",
-    "position": "ss"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "a.j. howard",
-    "first": "a.j.",
-    "last": "howard",
-    "position": "ss"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "nate ebner",
-    "first": "nate",
-    "last": "ebner",
-    "position": "ss"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "malik gant",
-    "first": "malik",
-    "last": "gant",
-    "position": "ss"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "devin mccourty",
-    "first": "devin",
-    "last": "mccourty",
-    "position": "fs"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "duron harmon",
-    "first": "duron",
-    "last": "harmon",
-    "position": "fs"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "terrence brooks",
-    "first": "terrence",
-    "last": "brooks",
-    "position": "fs"
-  },
-  {
-    "team": "new england patriots",
-    "symbol": "NE",
-    "fullname": "ryan allen",
+    "fullname": "ryan davis",
     "first": "ryan",
-    "last": "allen",
-    "position": "p"
+    "last": "davis",
+    "position": "wr"
   },
   {
     "team": "new england patriots",
     "symbol": "NE",
-    "fullname": "jake bailey",
-    "first": "jake",
-    "last": "bailey",
-    "position": "p"
+    "fullname": "james develin",
+    "first": "james",
+    "last": "develin",
+    "position": "fb"
   },
   {
     "team": "new england patriots",
     "symbol": "NE",
-    "fullname": "joe cardona",
-    "first": "joe",
-    "last": "cardona",
-    "position": "ls"
+    "fullname": "phillip dorsett",
+    "first": "phillip",
+    "last": "dorsett",
+    "position": "wr"
   },
   {
     "team": "new england patriots",
     "symbol": "NE",
-    "fullname": "ryan allen",
-    "first": "ryan",
-    "last": "allen",
-    "position": "h"
+    "fullname": "julian edelman",
+    "first": "julian",
+    "last": "edelman",
+    "position": "wr"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "danny etling",
+    "first": "danny",
+    "last": "etling",
+    "position": "wr"
   },
   {
     "team": "new england patriots",
@@ -20320,60 +6944,164 @@
     "position": "k"
   },
   {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "marcus mariota",
-    "first": "marcus",
-    "last": "mariota",
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "damien harris",
+    "first": "damien",
+    "last": "harris",
+    "position": "rb"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "maurice harris",
+    "first": "maurice",
+    "last": "harris",
+    "position": "wr"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "n'keal harry",
+    "first": "n'keal",
+    "last": "harry",
+    "position": "wr"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "brian hoyer",
+    "first": "brian",
+    "last": "hoyer",
     "position": "qb"
   },
   {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "ryan tannehill",
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "dontrelle inman",
+    "first": "dontrelle",
+    "last": "inman",
+    "position": "wr"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "ryan izzo",
     "first": "ryan",
-    "last": "tannehill",
+    "last": "izzo",
+    "position": "te"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "jakob johnson",
+    "first": "jakob",
+    "last": "johnson",
+    "position": "te"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "lance kendricks",
+    "first": "lance",
+    "last": "kendricks",
+    "position": "te"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "matt lacosse",
+    "first": "matt",
+    "last": "lacosse",
+    "position": "te"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "cameron meredith",
+    "first": "cameron",
+    "last": "meredith",
+    "position": "wr"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "jakobi meyers",
+    "first": "jakobi",
+    "last": "meyers",
+    "position": "wr"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "sony michel",
+    "first": "sony",
+    "last": "michel",
+    "position": "rb"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "gunner olszewski",
+    "first": "gunner",
+    "last": "olszewski",
+    "position": "wr"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "damoun patterson",
+    "first": "damoun",
+    "last": "patterson",
+    "position": "wr"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "matthew slater",
+    "first": "matthew",
+    "last": "slater",
+    "position": "wr"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "jarrett stidham",
+    "first": "jarrett",
+    "last": "stidham",
     "position": "qb"
   },
   {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "logan woodside",
-    "first": "logan",
-    "last": "woodside",
-    "position": "qb"
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "demaryius thomas",
+    "first": "demaryius",
+    "last": "thomas",
+    "position": "wr"
   },
   {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "derrick henry",
-    "first": "derrick",
-    "last": "henry",
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "benjamin watson",
+    "first": "benjamin",
+    "last": "watson",
+    "position": "te"
+  },
+  {
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "james white",
+    "first": "james",
+    "last": "white",
     "position": "rb"
   },
   {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "dion lewis",
-    "first": "dion",
-    "last": "lewis",
-    "position": "rb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "david fluellen",
-    "first": "david",
-    "last": "fluellen",
-    "position": "rb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "jeremy mcnichols",
-    "first": "jeremy",
-    "last": "mcnichols",
-    "position": "rb"
+    "team": "new england patriots",
+    "symbol": "NE",
+    "fullname": "josh gordon",
+    "first": "josh",
+    "last": "gordon",
+    "position": "wr"
   },
   {
     "team": "tennessee titans",
@@ -20386,18 +7114,10 @@
   {
     "team": "tennessee titans",
     "symbol": "TEN",
-    "fullname": "dalyn dawkins",
-    "first": "dalyn",
-    "last": "dawkins",
-    "position": "rb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "david fluellen",
-    "first": "david",
-    "last": "fluellen",
-    "position": "fb"
+    "fullname": "aj brown",
+    "first": "aj",
+    "last": "brown",
+    "position": "wr"
   },
   {
     "team": "tennessee titans",
@@ -20410,9 +7130,57 @@
   {
     "team": "tennessee titans",
     "symbol": "TEN",
-    "fullname": "a.j. brown",
-    "first": "a.j.",
-    "last": "brown",
+    "fullname": "dalyn dawkins",
+    "first": "dalyn",
+    "last": "dawkins",
+    "position": "rb"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "anthony firkser",
+    "first": "anthony",
+    "last": "firkser",
+    "position": "te"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "david fluellen",
+    "first": "david",
+    "last": "fluellen",
+    "position": "rb"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "derrick henry",
+    "first": "derrick",
+    "last": "henry",
+    "position": "rb"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "parker hesse",
+    "first": "parker",
+    "last": "hesse",
+    "position": "te"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "ryan hewitt",
+    "first": "ryan",
+    "last": "hewitt",
+    "position": "te"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "cody hollister",
+    "first": "cody",
+    "last": "hollister",
     "position": "wr"
   },
   {
@@ -20426,22 +7194,6 @@
   {
     "team": "tennessee titans",
     "symbol": "TEN",
-    "fullname": "taywan taylor",
-    "first": "taywan",
-    "last": "taylor",
-    "position": "wr"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "tajae sharpe",
-    "first": "tajae",
-    "last": "sharpe",
-    "position": "wr"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
     "fullname": "darius jennings",
     "first": "darius",
     "last": "jennings",
@@ -20450,9 +7202,49 @@
   {
     "team": "tennessee titans",
     "symbol": "TEN",
-    "fullname": "cameron batson",
-    "first": "cameron",
-    "last": "batson",
+    "fullname": "dion lewis",
+    "first": "dion",
+    "last": "lewis",
+    "position": "rb"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "marcus mariota",
+    "first": "marcus",
+    "last": "mariota",
+    "position": "qb"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "tanner mcevoy",
+    "first": "tanner",
+    "last": "mcevoy",
+    "position": "wr"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "jeremy mcnichols",
+    "first": "jeremy",
+    "last": "mcnichols",
+    "position": "rb"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "mycole pruitt",
+    "first": "mycole",
+    "last": "pruitt",
+    "position": "te"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "anthony ratliff-williams",
+    "first": "anthony",
+    "last": "ratliff-williams",
     "position": "wr"
   },
   {
@@ -20466,25 +7258,41 @@
   {
     "team": "tennessee titans",
     "symbol": "TEN",
-    "fullname": "anthony ratliff-williams",
-    "first": "anthony",
-    "last": "ratliff-williams",
+    "fullname": "tajae sharpe",
+    "first": "tajae",
+    "last": "sharpe",
     "position": "wr"
   },
   {
     "team": "tennessee titans",
     "symbol": "TEN",
-    "fullname": "cody hollister",
-    "first": "cody",
-    "last": "hollister",
-    "position": "wr"
+    "fullname": "jonnu smith",
+    "first": "jonnu",
+    "last": "smith",
+    "position": "te"
   },
   {
     "team": "tennessee titans",
     "symbol": "TEN",
-    "fullname": "joseph parker",
-    "first": "joseph",
-    "last": "parker",
+    "fullname": "ryan succop",
+    "first": "ryan",
+    "last": "succop",
+    "position": "k"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "ryan tannehill",
+    "first": "ryan",
+    "last": "tannehill",
+    "position": "qb"
+  },
+  {
+    "team": "tennessee titans",
+    "symbol": "TEN",
+    "fullname": "taywan taylor",
+    "first": "taywan",
+    "last": "taylor",
     "position": "wr"
   },
   {
@@ -20506,34 +7314,10 @@
   {
     "team": "tennessee titans",
     "symbol": "TEN",
-    "fullname": "jonnu smith",
-    "first": "jonnu",
-    "last": "smith",
-    "position": "te"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "anthony firkser",
-    "first": "anthony",
-    "last": "firkser",
-    "position": "te"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "mycole pruitt",
-    "first": "mycole",
-    "last": "pruitt",
-    "position": "te"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "parker hesse",
-    "first": "parker",
-    "last": "hesse",
-    "position": "te"
+    "fullname": "papi white",
+    "first": "papi",
+    "last": "white",
+    "position": "wr"
   },
   {
     "team": "tennessee titans",
@@ -20546,450 +7330,18 @@
   {
     "team": "tennessee titans",
     "symbol": "TEN",
-    "fullname": "ryan hewitt",
-    "first": "ryan",
-    "last": "hewitt",
-    "position": "te"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "taylor lewan",
-    "first": "taylor",
-    "last": "lewan",
-    "position": "lt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "austin pasztor",
-    "first": "austin",
-    "last": "pasztor",
-    "position": "lt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "david quessenberry",
-    "first": "david",
-    "last": "quessenberry",
-    "position": "lt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "rodger saffold",
-    "first": "rodger",
-    "last": "saffold",
-    "position": "lg"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "tyler marz",
-    "first": "tyler",
-    "last": "marz",
-    "position": "lg"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "jamil douglas",
-    "first": "jamil",
-    "last": "douglas",
-    "position": "lg"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "ben jones",
-    "first": "ben",
-    "last": "jones",
-    "position": "c"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "corey levin",
-    "first": "corey",
-    "last": "levin",
-    "position": "c"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "hroniss grasu",
-    "first": "hroniss",
-    "last": "grasu",
-    "position": "c"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "kevin pamphile",
-    "first": "kevin",
-    "last": "pamphile",
-    "position": "rg"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "nate davis",
-    "first": "nate",
-    "last": "davis",
-    "position": "rg"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "jack conklin",
-    "first": "jack",
-    "last": "conklin",
-    "position": "rt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "dennis kelly",
-    "first": "dennis",
-    "last": "kelly",
-    "position": "rt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ldt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "daquan jones",
-    "first": "daquan",
-    "last": "jones",
-    "position": "lde"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "brent urban",
-    "first": "brent",
-    "last": "urban",
-    "position": "lde"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "derick roberson",
-    "first": "derick",
-    "last": "roberson",
-    "position": "lde"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "austin johnson",
-    "first": "austin",
-    "last": "johnson",
-    "position": "ndt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "jeffery simmons",
-    "first": "jeffery",
-    "last": "simmons",
-    "position": "ndt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "isaiah mack",
-    "first": "isaiah",
-    "last": "mack",
-    "position": "ndt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "frank herron",
-    "first": "frank",
-    "last": "herron",
-    "position": "ndt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "rdt"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "jurrell casey",
-    "first": "jurrell",
-    "last": "casey",
-    "position": "rde"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "matt dickerson",
-    "first": "matt",
-    "last": "dickerson",
-    "position": "rde"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "amani bledsoe",
-    "first": "amani",
-    "last": "bledsoe",
-    "position": "rde"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "mlb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "harold landry",
-    "first": "harold",
-    "last": "landry",
-    "position": "slb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "kamalei correa",
-    "first": "kamalei",
-    "last": "correa",
-    "position": "slb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "d'andre walker",
-    "first": "d'andre",
-    "last": "walker",
-    "position": "slb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "gimel president",
-    "first": "gimel",
-    "last": "president",
-    "position": "slb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "cameron wake",
-    "first": "cameron",
-    "last": "wake",
-    "position": "wlb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "sharif finch",
-    "first": "sharif",
-    "last": "finch",
-    "position": "wlb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "latroy lewis",
-    "first": "latroy",
-    "last": "lewis",
-    "position": "wlb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "malcolm butler",
-    "first": "malcolm",
-    "last": "butler",
-    "position": "rcb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "leshaun sims",
-    "first": "leshaun",
-    "last": "sims",
-    "position": "rcb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "kenneth durden",
-    "first": "kenneth",
-    "last": "durden",
-    "position": "rcb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "mike jordan",
-    "first": "mike",
-    "last": "jordan",
-    "position": "rcb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "logan ryan",
+    "fullname": "logan woodside",
     "first": "logan",
-    "last": "ryan",
-    "position": "lcb"
+    "last": "woodside",
+    "position": "qb"
   },
   {
     "team": "tennessee titans",
     "symbol": "TEN",
-    "fullname": "adoree' jackson",
-    "first": "adoree'",
-    "last": "jackson",
-    "position": "lcb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "joshua kalu",
-    "first": "joshua",
-    "last": "kalu",
-    "position": "lcb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "tye smith",
-    "first": "tye",
-    "last": "smith",
-    "position": "lcb"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "kenny vaccaro",
-    "first": "kenny",
-    "last": "vaccaro",
-    "position": "ss"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "amani hooker",
-    "first": "amani",
-    "last": "hooker",
-    "position": "ss"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "damon webb",
-    "first": "damon",
-    "last": "webb",
-    "position": "ss"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "jojo tillery",
-    "first": "jojo",
-    "last": "tillery",
-    "position": "ss"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "ladarius wiley",
-    "first": "ladarius",
-    "last": "wiley",
-    "position": "ss"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "kevin byard",
-    "first": "kevin",
-    "last": "byard",
-    "position": "fs"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "dane cruikshank",
-    "first": "dane",
-    "last": "cruikshank",
-    "position": "fs"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "kareem orr",
-    "first": "kareem",
-    "last": "orr",
-    "position": "fs"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "d'andre payne",
-    "first": "d'andre",
-    "last": "payne",
-    "position": "fs"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "brett kern",
-    "first": "brett",
-    "last": "kern",
-    "position": "p"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "austin barnard",
-    "first": "austin",
-    "last": "barnard",
-    "position": "p"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "beau brinkley",
-    "first": "beau",
-    "last": "brinkley",
-    "position": "ls"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "brett kern",
-    "first": "brett",
-    "last": "kern",
-    "position": "h"
-  },
-  {
-    "team": "tennessee titans",
-    "symbol": "TEN",
-    "fullname": "ryan succop",
-    "first": "ryan",
-    "last": "succop",
-    "position": "k"
+    "fullname": "cameron batson",
+    "first": "cameron",
+    "last": "batson",
+    "position": "wr"
   },
   {
     "team": "buffalo bills",
@@ -21010,18 +7362,74 @@
   {
     "team": "buffalo bills",
     "symbol": "BUF",
-    "fullname": "tyree jackson",
-    "first": "tyree",
-    "last": "jackson",
-    "position": "qb"
+    "fullname": "cole beasley",
+    "first": "cole",
+    "last": "beasley",
+    "position": "wr"
   },
   {
     "team": "buffalo bills",
     "symbol": "BUF",
-    "fullname": "lesean mccoy",
-    "first": "lesean",
-    "last": "mccoy",
-    "position": "rb"
+    "fullname": "nate becker",
+    "first": "nate",
+    "last": "becker",
+    "position": "te"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "victor bolden jr.",
+    "first": "victor",
+    "last": "bolden jr.",
+    "position": "wr"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "john brown",
+    "first": "john",
+    "last": "brown",
+    "position": "wr"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "kyle carter",
+    "first": "kyle",
+    "last": "carter",
+    "position": "te"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "jason croom",
+    "first": "jason",
+    "last": "croom",
+    "position": "te"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "patrick dimarco",
+    "first": "patrick",
+    "last": "dimarco",
+    "position": "fb"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "nick easley",
+    "first": "nick",
+    "last": "easley",
+    "position": "wr"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "robert foster",
+    "first": "robert",
+    "last": "foster",
+    "position": "wr"
   },
   {
     "team": "buffalo bills",
@@ -21034,18 +7442,74 @@
   {
     "team": "buffalo bills",
     "symbol": "BUF",
-    "fullname": "devin singletary",
-    "first": "devin",
-    "last": "singletary",
+    "fullname": "stephen hauschka",
+    "first": "stephen",
+    "last": "hauschka",
+    "position": "k"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "tyree jackson",
+    "first": "tyree",
+    "last": "jackson",
+    "position": "qb"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "zay jones",
+    "first": "zay",
+    "last": "jones",
+    "position": "wr"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "dawson knox",
+    "first": "dawson",
+    "last": "knox",
+    "position": "te"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "tyler kroft",
+    "first": "tyler",
+    "last": "kroft",
+    "position": "te"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "ray-ray mccloud",
+    "first": "ray-ray",
+    "last": "mccloud",
+    "position": "wr"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "lesean mccoy",
+    "first": "lesean",
+    "last": "mccoy",
     "position": "rb"
   },
   {
     "team": "buffalo bills",
     "symbol": "BUF",
-    "fullname": "t.j. yeldon",
-    "first": "t.j.",
-    "last": "yeldon",
-    "position": "rb"
+    "fullname": "isaiah mckenzie",
+    "first": "isaiah",
+    "last": "mckenzie",
+    "position": "wr"
+  },
+  {
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "chase mclaughlin",
+    "first": "chase",
+    "last": "mclaughlin",
+    "position": "k"
   },
   {
     "team": "buffalo bills",
@@ -21066,49 +7530,9 @@
   {
     "team": "buffalo bills",
     "symbol": "BUF",
-    "fullname": "christian wade",
-    "first": "christian",
-    "last": "wade",
-    "position": "rb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "patrick dimarco",
-    "first": "patrick",
-    "last": "dimarco",
-    "position": "fb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "john brown",
-    "first": "john",
-    "last": "brown",
-    "position": "wr"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "zay jones",
-    "first": "zay",
-    "last": "jones",
-    "position": "wr"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "cole beasley",
-    "first": "cole",
-    "last": "beasley",
-    "position": "wr"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "robert foster",
-    "first": "robert",
-    "last": "foster",
+    "fullname": "cam phillips",
+    "first": "cam",
+    "last": "phillips",
     "position": "wr"
   },
   {
@@ -21122,82 +7546,18 @@
   {
     "team": "buffalo bills",
     "symbol": "BUF",
-    "fullname": "ray-ray mccloud",
-    "first": "ray-ray",
-    "last": "mccloud",
-    "position": "wr"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "isaiah mckenzie",
-    "first": "isaiah",
-    "last": "mckenzie",
-    "position": "wr"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "duke williams",
-    "first": "duke",
-    "last": "williams",
-    "position": "wr"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "da'mari scott",
-    "first": "da'mari",
-    "last": "scott",
-    "position": "wr"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "victor bolden",
-    "first": "victor",
-    "last": "bolden",
-    "position": "wr"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "cam phillips",
-    "first": "cam",
-    "last": "phillips",
-    "position": "wr"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "david sills",
+    "fullname": "david sills v",
     "first": "david",
-    "last": "sills",
+    "last": "sills v",
     "position": "wr"
   },
   {
     "team": "buffalo bills",
     "symbol": "BUF",
-    "fullname": "nick easley",
-    "first": "nick",
-    "last": "easley",
-    "position": "wr"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "tyler kroft",
-    "first": "tyler",
-    "last": "kroft",
-    "position": "te"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "dawson knox",
-    "first": "dawson",
-    "last": "knox",
-    "position": "te"
+    "fullname": "devin singletary",
+    "first": "devin",
+    "last": "singletary",
+    "position": "rb"
   },
   {
     "team": "buffalo bills",
@@ -21205,14 +7565,6 @@
     "fullname": "lee smith",
     "first": "lee",
     "last": "smith",
-    "position": "te"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "jason croom",
-    "first": "jason",
-    "last": "croom",
     "position": "te"
   },
   {
@@ -21226,14 +7578,6 @@
   {
     "team": "buffalo bills",
     "symbol": "BUF",
-    "fullname": "nate becker",
-    "first": "nate",
-    "last": "becker",
-    "position": "te"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
     "fullname": "keith towbridge",
     "first": "keith",
     "last": "towbridge",
@@ -21242,610 +7586,26 @@
   {
     "team": "buffalo bills",
     "symbol": "BUF",
-    "fullname": "dion dawkins",
-    "first": "dion",
-    "last": "dawkins",
-    "position": "lt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "jeremiah sirles",
-    "first": "jeremiah",
-    "last": "sirles",
-    "position": "lt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "conor mcdermott",
-    "first": "conor",
-    "last": "mcdermott",
-    "position": "lt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "quinton spain",
-    "first": "quinton",
-    "last": "spain",
-    "position": "lg"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "wyatt teller",
-    "first": "wyatt",
-    "last": "teller",
-    "position": "lg"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "vladimir ducasse",
-    "first": "vladimir",
-    "last": "ducasse",
-    "position": "lg"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "mitch morse",
-    "first": "mitch",
-    "last": "morse",
-    "position": "c"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "russell bodine",
-    "first": "russell",
-    "last": "bodine",
-    "position": "c"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "spencer long",
-    "first": "spencer",
-    "last": "long",
-    "position": "rg"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "jon feliciano",
-    "first": "jon",
-    "last": "feliciano",
-    "position": "rg"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "ike boettger",
-    "first": "ike",
-    "last": "boettger",
-    "position": "rg"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "cody ford",
-    "first": "cody",
-    "last": "ford",
-    "position": "rt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "ty nsekhe",
-    "first": "ty",
-    "last": "nsekhe",
-    "position": "rt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "laadrian waddle",
-    "first": "laadrian",
-    "last": "waddle",
-    "position": "rt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "de'ondre wesley",
-    "first": "de'ondre",
-    "last": "wesley",
-    "position": "rt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "star lotulelei",
-    "first": "star",
-    "last": "lotulelei",
-    "position": "ldt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "harrison phillips",
-    "first": "harrison",
-    "last": "phillips",
-    "position": "ldt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "l.t. walton",
-    "first": "l.t.",
-    "last": "walton",
-    "position": "ldt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "trent murphy",
-    "first": "trent",
-    "last": "murphy",
-    "position": "lde"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "shaq lawson",
-    "first": "shaq",
-    "last": "lawson",
-    "position": "lde"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "mike love",
-    "first": "mike",
-    "last": "love",
-    "position": "lde"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "jordan phillips",
-    "first": "jordan",
-    "last": "phillips",
-    "position": "rdt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "ed oliver",
-    "first": "ed",
-    "last": "oliver",
-    "position": "rdt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "robert thomas",
-    "first": "robert",
-    "last": "thomas",
-    "position": "rdt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "kyle peko",
-    "first": "kyle",
-    "last": "peko",
-    "position": "rdt"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "jerry hughes",
-    "first": "jerry",
-    "last": "hughes",
-    "position": "rde"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "eddie yarbrough",
-    "first": "eddie",
-    "last": "yarbrough",
-    "position": "rde"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "darryl johnson",
-    "first": "darryl",
-    "last": "johnson",
-    "position": "rde"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "eli harold",
-    "first": "eli",
-    "last": "harold",
-    "position": "rde"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "tremaine edmunds",
-    "first": "tremaine",
-    "last": "edmunds",
-    "position": "mlb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "julian stanford",
-    "first": "julian",
-    "last": "stanford",
-    "position": "mlb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "vosean joseph",
-    "first": "vosean",
-    "last": "joseph",
-    "position": "mlb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "juwan foggie",
-    "first": "juwan",
-    "last": "foggie",
-    "position": "mlb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "lorenzo alexander",
-    "first": "lorenzo",
-    "last": "alexander",
-    "position": "slb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "deon lacey",
-    "first": "deon",
-    "last": "lacey",
-    "position": "slb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "eli harold",
-    "first": "eli",
-    "last": "harold",
-    "position": "slb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "matt milano",
-    "first": "matt",
-    "last": "milano",
-    "position": "wlb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "corey thompson",
-    "first": "corey",
-    "last": "thompson",
-    "position": "wlb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "tyrel dodson",
-    "first": "tyrel",
-    "last": "dodson",
-    "position": "wlb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "levi wallace",
-    "first": "levi",
-    "last": "wallace",
-    "position": "rcb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "e.j. gaines",
-    "first": "e.j.",
-    "last": "gaines",
-    "position": "rcb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "kevin johnson",
-    "first": "kevin",
-    "last": "johnson",
-    "position": "rcb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "ryan lewis",
-    "first": "ryan",
-    "last": "lewis",
-    "position": "rcb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "cam lewis",
-    "first": "cam",
-    "last": "lewis",
-    "position": "rcb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "tre'davious white",
-    "first": "tre'davious",
-    "last": "white",
-    "position": "lcb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "taron johnson",
-    "first": "taron",
-    "last": "johnson",
-    "position": "lcb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "siran neal",
-    "first": "siran",
-    "last": "neal",
-    "position": "lcb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "lafayette pitts",
-    "first": "lafayette",
-    "last": "pitts",
-    "position": "lcb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "denzel rice",
-    "first": "denzel",
-    "last": "rice",
-    "position": "lcb"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "micah hyde",
-    "first": "micah",
-    "last": "hyde",
-    "position": "ss"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "maurice alexander",
-    "first": "maurice",
-    "last": "alexander",
-    "position": "ss"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "dean marlowe",
-    "first": "dean",
-    "last": "marlowe",
-    "position": "ss"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "jordan poyer",
-    "first": "jordan",
-    "last": "poyer",
-    "position": "fs"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "rafael bush",
-    "first": "rafael",
-    "last": "bush",
-    "position": "fs"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "jaquan johnson",
-    "first": "jaquan",
-    "last": "johnson",
-    "position": "fs"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "corey bojorquez",
-    "first": "corey",
-    "last": "bojorquez",
-    "position": "p"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "cory carter",
-    "first": "cory",
-    "last": "carter",
-    "position": "p"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "reid ferguson",
-    "first": "reid",
-    "last": "ferguson",
-    "position": "ls"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "harrison phillips",
-    "first": "harrison",
-    "last": "phillips",
-    "position": "ls"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "corey bojorquez",
-    "first": "corey",
-    "last": "bojorquez",
-    "position": "h"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "stephen hauschka",
-    "first": "stephen",
-    "last": "hauschka",
-    "position": "k"
-  },
-  {
-    "team": "buffalo bills",
-    "symbol": "BUF",
-    "fullname": "chase mclaughlin",
-    "first": "chase",
-    "last": "mclaughlin",
-    "position": "k"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "dak prescott",
-    "first": "dak",
-    "last": "prescott",
-    "position": "qb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "cooper rush",
-    "first": "cooper",
-    "last": "rush",
-    "position": "qb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "mike white",
-    "first": "mike",
-    "last": "white",
-    "position": "qb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "ezekiel elliott",
-    "first": "ezekiel",
-    "last": "elliott",
+    "fullname": "christian wade",
+    "first": "christian",
+    "last": "wade",
     "position": "rb"
   },
   {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "tony pollard",
-    "first": "tony",
-    "last": "pollard",
-    "position": "rb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "mike weber",
-    "first": "mike",
-    "last": "weber",
-    "position": "rb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "darius jackson",
-    "first": "darius",
-    "last": "jackson",
-    "position": "rb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "jordan chunn",
-    "first": "jordan",
-    "last": "chunn",
-    "position": "rb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "jamize olawale",
-    "first": "jamize",
-    "last": "olawale",
-    "position": "fb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "amari cooper",
-    "first": "amari",
-    "last": "cooper",
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "duke williams",
+    "first": "duke",
+    "last": "williams",
     "position": "wr"
   },
   {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "michael gallup",
-    "first": "michael",
-    "last": "gallup",
-    "position": "wr"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "randall cobb",
-    "first": "randall",
-    "last": "cobb",
-    "position": "wr"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "allen hurns",
-    "first": "allen",
-    "last": "hurns",
-    "position": "wr"
+    "team": "buffalo bills",
+    "symbol": "BUF",
+    "fullname": "tj yeldon",
+    "first": "tj",
+    "last": "yeldon",
+    "position": "rb"
   },
   {
     "team": "dallas cowboys",
@@ -21866,25 +7626,33 @@
   {
     "team": "dallas cowboys",
     "symbol": "DAL",
-    "fullname": "ced wilson",
-    "first": "ced",
-    "last": "wilson",
+    "fullname": "taryn christion",
+    "first": "taryn",
+    "last": "christion",
+    "position": "qb"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "jordan chunn",
+    "first": "jordan",
+    "last": "chunn",
+    "position": "rb"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "randall cobb",
+    "first": "randall",
+    "last": "cobb",
     "position": "wr"
   },
   {
     "team": "dallas cowboys",
     "symbol": "DAL",
-    "fullname": "lance lenoir",
-    "first": "lance",
-    "last": "lenoir",
-    "position": "wr"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "devin smith",
-    "first": "devin",
-    "last": "smith",
+    "fullname": "amari cooper",
+    "first": "amari",
+    "last": "cooper",
     "position": "wr"
   },
   {
@@ -21898,9 +7666,9 @@
   {
     "team": "dallas cowboys",
     "symbol": "DAL",
-    "fullname": "jon'vea johnson",
-    "first": "jon'vea",
-    "last": "johnson",
+    "fullname": "michael gallup",
+    "first": "michael",
+    "last": "gallup",
     "position": "wr"
   },
   {
@@ -21914,10 +7682,10 @@
   {
     "team": "dallas cowboys",
     "symbol": "DAL",
-    "fullname": "jason witten",
-    "first": "jason",
-    "last": "witten",
-    "position": "te"
+    "fullname": "darius jackson",
+    "first": "darius",
+    "last": "jackson",
+    "position": "rb"
   },
   {
     "team": "dallas cowboys",
@@ -21930,530 +7698,18 @@
   {
     "team": "dallas cowboys",
     "symbol": "DAL",
-    "fullname": "dalton schultz",
-    "first": "dalton",
-    "last": "schultz",
-    "position": "te"
+    "fullname": "jon'vea johnson",
+    "first": "jon'vea",
+    "last": "johnson",
+    "position": "wr"
   },
   {
     "team": "dallas cowboys",
     "symbol": "DAL",
-    "fullname": "rico gathers",
-    "first": "rico",
-    "last": "gathers",
-    "position": "te"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "tyron smith",
-    "first": "tyron",
-    "last": "smith",
-    "position": "lt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "cameron fleming",
-    "first": "cameron",
-    "last": "fleming",
-    "position": "lt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "mitch hyatt",
-    "first": "mitch",
-    "last": "hyatt",
-    "position": "lt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "brandon knight",
-    "first": "brandon",
-    "last": "knight",
-    "position": "lt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "connor williams",
-    "first": "connor",
-    "last": "williams",
-    "position": "lg"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "connor mcgovern",
-    "first": "connor",
-    "last": "mcgovern",
-    "position": "lg"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "cody wichmann",
-    "first": "cody",
-    "last": "wichmann",
-    "position": "lg"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "travis frederick",
-    "first": "travis",
-    "last": "frederick",
-    "position": "c"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "joe looney",
-    "first": "joe",
-    "last": "looney",
-    "position": "c"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "adam redmond",
-    "first": "adam",
-    "last": "redmond",
-    "position": "c"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "zack martin",
-    "first": "zack",
-    "last": "martin",
-    "position": "rg"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "xavier su'a-filo",
-    "first": "xavier",
-    "last": "su'a-filo",
-    "position": "rg"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "la'el collins",
-    "first": "la'el",
-    "last": "collins",
-    "position": "rt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "cameron fleming",
-    "first": "cameron",
-    "last": "fleming",
-    "position": "rt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "jake campos",
-    "first": "jake",
-    "last": "campos",
-    "position": "rt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "derrick puni",
-    "first": "derrick",
-    "last": "puni",
-    "position": "rt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "maliek collins",
-    "first": "maliek",
-    "last": "collins",
-    "position": "ldt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "trysten hill",
-    "first": "trysten",
-    "last": "hill",
-    "position": "ldt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "antwaun woods",
-    "first": "antwaun",
-    "last": "woods",
-    "position": "ldt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "ricky walker",
-    "first": "ricky",
-    "last": "walker",
-    "position": "ldt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "demarcus lawrence",
-    "first": "demarcus",
-    "last": "lawrence",
-    "position": "lde"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "kerry hyder",
-    "first": "kerry",
-    "last": "hyder",
-    "position": "lde"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "dorance armstrong",
-    "first": "dorance",
-    "last": "armstrong",
-    "position": "lde"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "joe jackson",
-    "first": "joe",
-    "last": "jackson",
-    "position": "lde"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "daniel wise",
-    "first": "daniel",
-    "last": "wise",
-    "position": "lde"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "none listed",
-    "first": "none",
-    "last": "listed",
-    "position": "ndt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "tyrone crawford",
-    "first": "tyrone",
-    "last": "crawford",
-    "position": "rdt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "christian covington",
-    "first": "christian",
-    "last": "covington",
-    "position": "rdt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "daniel ross",
-    "first": "daniel",
-    "last": "ross",
-    "position": "rdt"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "robert quinn",
-    "first": "robert",
-    "last": "quinn",
-    "position": "rde"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "taco charlton",
-    "first": "taco",
-    "last": "charlton",
-    "position": "rde"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "jalen jelks",
-    "first": "jalen",
-    "last": "jelks",
-    "position": "rde"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "randy gregory",
-    "first": "randy",
-    "last": "gregory",
-    "position": "rde"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "jaylon smith",
-    "first": "jaylon",
-    "last": "smith",
-    "position": "mlb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "justin march-lillard",
-    "first": "justin",
-    "last": "march-lillard",
-    "position": "mlb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "andrew dowell",
-    "first": "andrew",
-    "last": "dowell",
-    "position": "mlb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "sean lee",
-    "first": "sean",
-    "last": "lee",
-    "position": "slb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "chris covington",
-    "first": "chris",
-    "last": "covington",
-    "position": "slb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "kyle queiro",
-    "first": "kyle",
-    "last": "queiro",
-    "position": "slb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "nate hall",
-    "first": "nate",
-    "last": "hall",
-    "position": "slb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "leighton vander esch",
-    "first": "leighton",
-    "last": "vander",
-    "position": "wlb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "joe thomas",
-    "first": "joe",
-    "last": "thomas",
-    "position": "wlb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "luke gifford",
-    "first": "luke",
-    "last": "gifford",
-    "position": "wlb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "byron jones",
-    "first": "byron",
-    "last": "jones",
-    "position": "rcb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "anthony brown",
-    "first": "anthony",
-    "last": "brown",
-    "position": "rcb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "treston decoud",
-    "first": "treston",
-    "last": "decoud",
-    "position": "rcb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "chris westry",
-    "first": "chris",
-    "last": "westry",
-    "position": "rcb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "chidobe awuzie",
-    "first": "chidobe",
-    "last": "awuzie",
-    "position": "lcb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "jourdan lewis",
-    "first": "jourdan",
-    "last": "lewis",
-    "position": "lcb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "michael jackson",
-    "first": "michael",
-    "last": "jackson",
-    "position": "lcb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "c.j. goodwin",
-    "first": "c.j.",
-    "last": "goodwin",
-    "position": "lcb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "donovan olumba",
-    "first": "donovan",
-    "last": "olumba",
-    "position": "lcb"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "jeff heath",
-    "first": "jeff",
-    "last": "heath",
-    "position": "ss"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "george iloka",
-    "first": "george",
-    "last": "iloka",
-    "position": "ss"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "kavon frazier",
-    "first": "kavon",
-    "last": "frazier",
-    "position": "ss"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "jameill showers",
-    "first": "jameill",
-    "last": "showers",
-    "position": "ss"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "xavier woods",
-    "first": "xavier",
-    "last": "woods",
-    "position": "fs"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "darian thompson",
-    "first": "darian",
-    "last": "thompson",
-    "position": "fs"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "donovan wilson",
-    "first": "donovan",
-    "last": "wilson",
-    "position": "fs"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "chris jones",
-    "first": "chris",
-    "last": "jones",
-    "position": "p"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "kasey redfern",
-    "first": "kasey",
-    "last": "redfern",
-    "position": "p"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "l.p. ladouceur",
-    "first": "l.p.",
-    "last": "ladouceur",
-    "position": "ls"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "drew scott",
-    "first": "drew",
-    "last": "scott",
-    "position": "ls"
-  },
-  {
-    "team": "dallas cowboys",
-    "symbol": "DAL",
-    "fullname": "chris jones",
-    "first": "chris",
-    "last": "jones",
-    "position": "h"
+    "fullname": "marcus lucas",
+    "first": "marcus",
+    "last": "lucas",
+    "position": "wr"
   },
   {
     "team": "dallas cowboys",
@@ -22462,5 +7718,117 @@
     "first": "brett",
     "last": "maher",
     "position": "k"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "codey mcelroy",
+    "first": "codey",
+    "last": "mcelroy",
+    "position": "wr"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "alfred morris",
+    "first": "alfred",
+    "last": "morris",
+    "position": "rb"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "jamize olawale",
+    "first": "jamize",
+    "last": "olawale",
+    "position": "fb"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "tony pollard",
+    "first": "tony",
+    "last": "pollard",
+    "position": "rb"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "dak prescott",
+    "first": "dak",
+    "last": "prescott",
+    "position": "qb"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "cooper rush",
+    "first": "cooper",
+    "last": "rush",
+    "position": "qb"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "dalton schultz",
+    "first": "dalton",
+    "last": "schultz",
+    "position": "te"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "devin smith",
+    "first": "devin",
+    "last": "smith",
+    "position": "wr"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "mike weber",
+    "first": "mike",
+    "last": "weber",
+    "position": "rb"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "mike white",
+    "first": "mike",
+    "last": "white",
+    "position": "qb"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "cedrick wilson",
+    "first": "cedrick",
+    "last": "wilson",
+    "position": "wr"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "jason witten",
+    "first": "jason",
+    "last": "witten",
+    "position": "te"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "ryan yurachek",
+    "first": "ryan",
+    "last": "yurachek",
+    "position": "fb"
+  },
+  {
+    "team": "dallas cowboys",
+    "symbol": "DAL",
+    "fullname": "ezekiel elliott",
+    "first": "ezekiel",
+    "last": "elliott",
+    "position": "rb"
   }
 ]


### PR DESCRIPTION
1. Change depthchart/roster source from cbs to ourlads.
2. new functions in utilities specifically for manipulating strings returned from depthchart function.
3. lowered min matching value for fuzzy in adp command.
4. pullroster.js only populate the players.json with players from following position: qb,rb,fb,wr,te,k.
5. most of the depthchart and pullroster have been rewritten because of the new source. 