### PR TITLE
Fix/162 adp update

### DIFF
--- a/lib/4for4.js
+++ b/lib/4for4.js
@@ -23,7 +23,7 @@ exports.getADP = string => new Promise((resolve, reject) => {
     ADP: {
       Yahoo: 0,
       ESPN: 0,
-      MFL: 0,
+      fourF4: 0,
       NFL: 0,
     },
   };
@@ -57,10 +57,10 @@ exports.getADP = string => new Promise((resolve, reject) => {
 
       // Get ADP
       // eq() is zero-indexed, so .nextAll().eq(3) == .next() chained four times.
-      playerObject.ADP.ESPN = parseInt(team.nextAll().eq(3).text(), 10);
-      playerObject.ADP.MFL = parseInt(team.nextAll().eq(5).text(), 10);
-      playerObject.ADP.NFL = parseInt(team.nextAll().eq(6).text(), 10);
-      playerObject.ADP.Yahoo = parseInt(team.nextAll().eq(7).text(), 10);
+      playerObject.ADP.ESPN = parseInt(team.nextAll().eq(2).text(), 10);
+      playerObject.ADP.fourF4 = parseInt(team.prevAll().eq(1).text(), 10);
+      playerObject.ADP.NFL = parseInt(team.nextAll().eq(5).text(), 10);
+      playerObject.ADP.Yahoo = parseInt(team.nextAll().eq(6).text(), 10);
 
       resolve(playerObject);
       return false;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -36,8 +36,8 @@ commands['!adp'] = nameObject =>
         returnString += `ESPN: ${resultObject.ADP.ESPN} (${utilities.convertToPickPosition(
           resultObject.ADP.ESPN,
         )})`;
-        returnString += `, MFL: ${resultObject.ADP.MFL} (${utilities.convertToPickPosition(
-          resultObject.ADP.MFL,
+        returnString += `, 4f4: ${resultObject.ADP.fourF4} (${utilities.convertToPickPosition(
+          resultObject.ADP.fourF4,
         )})`;
         returnString += `, Yahoo: ${resultObject.ADP.Yahoo} (${utilities.convertToPickPosition(
           resultObject.ADP.Yahoo,


### PR DESCRIPTION
To address changes to the adp source, this updates the source indexes to their new values (as of Jul 2020)  
It also removes the deprecated MFL "column" and replaces it with a 4f4 column

###Testing 
1. Run Bot
2. Trigger `adp` command with a valid player
3. Ensure returned data matches source (https://www.4for4.com/fantasy-football/adp?paging=0)

### Issue
https://github.com/chrisparsons83/FFDiscordBot/issues/162

